### PR TITLE
 update run_process action to send signals to whole process group. add ros_run action

### DIFF
--- a/scenario_execution/scenario_execution/actions/run_process.py
+++ b/scenario_execution/scenario_execution/actions/run_process.py
@@ -20,6 +20,7 @@ from threading import Thread
 from collections import deque
 import signal
 from scenario_execution.actions.base_action import BaseAction
+import os
 
 
 class RunProcess(BaseAction):
@@ -57,7 +58,11 @@ class RunProcess(BaseAction):
             self.executed = True
             try:
                 self.process = subprocess.Popen(
-                    self.command, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+                    self.command,
+                    preexec_fn=os.setsid, # run in a new process group
+                    stdout=subprocess.PIPE,
+                    stderr=subprocess.PIPE,
+                )
             except Exception as e:  # pylint: disable=broad-except
                 self.logger.error(str(e))
                 return py_trees.common.Status.FAILURE
@@ -76,7 +81,8 @@ class RunProcess(BaseAction):
                     out.close()
                 except ValueError:
                     pass
-
+                except Exception as e:  # pylint: disable=broad-except
+                    self.logger.error(f"Error while logging output: {e}")
             self.log_stdout_thread = Thread(target=log_output, args=(
                 self.process.stdout, self.get_logger_stdout(), self.output))
             self.log_stdout_thread.daemon = True  # die with the program
@@ -156,10 +162,12 @@ class RunProcess(BaseAction):
         if ret is None:
             # kill running process
             self.logger.info(f'Sending {signal.Signals(self.shutdown_signal).name} to process...')
-            self.process.send_signal(self.shutdown_signal)
-            self.process.wait(self.shutdown_timeout)
-            if self.process.poll() is None:
+            pgid = os.getpgid(self.process.pid)
+            os.killpg(pgid, self.shutdown_signal)
+            if self.process.poll():
+                self.logger.info(f"Waiting {self.shutdown_timeout}s for process to finish...")
+                self.process.wait(self.shutdown_timeout)
                 self.logger.info('Sending SIGKILL to process...')
-                self.process.send_signal(signal.SIGKILL)
+                os.killpg(pgid, signal.SIGKILL)
                 self.process.wait()
             self.logger.info('Process finished.')

--- a/scenario_execution_ros/scenario_execution_ros/actions/ros_run.py
+++ b/scenario_execution_ros/scenario_execution_ros/actions/ros_run.py
@@ -1,0 +1,27 @@
+# Copyright (C) 2025 Frederik Pasch
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions
+# and limitations under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+from scenario_execution.actions.base_action import ActionError
+from scenario_execution.actions.run_process import RunProcess
+import signal
+
+
+class RosRun(RunProcess):
+
+    def execute(self, package_name: str, executable_name: str, wait_for_shutdown: bool, shutdown_timeout: float):  # pylint: disable=arguments-differ
+        super().execute(None, wait_for_shutdown, shutdown_timeout, shutdown_signal=("", signal.SIGINT))
+        self.command = ["ros2", "run", package_name, executable_name]
+        self.logger.info(f'Command: {" ".join(self.command)}')

--- a/scenario_execution_ros/scenario_execution_ros/actions/ros_topic_check_data.py
+++ b/scenario_execution_ros/scenario_execution_ros/actions/ros_topic_check_data.py
@@ -46,6 +46,7 @@ class RosTopicCheckData(BaseAction):
         self.wait_for_first_message = None
         self.last_msg = None
         self.found = None
+        self.comparison_text = ""
 
     def setup(self, **kwargs):
         """
@@ -108,7 +109,7 @@ class RosTopicCheckData(BaseAction):
         if self.found is True:
             self.feedback_message = f"Found expected value in received message."
         else:
-            self.feedback_message = f"Received message does not contain expected value."
+            self.feedback_message = f"Received message does not contain expected value. Check: {self.comparison_text}"
 
     def check_data(self, msg):
         if msg is None or self.member_name is None or self.expected_value is None:
@@ -122,6 +123,7 @@ class RosTopicCheckData(BaseAction):
                 value = check_attr(msg)
             except AttributeError:
                 self.feedback_message = f"Member name not found {self.member_name}"
+        self.comparison_text = f"{value} {self.comparison_operator.__name__} {self.expected_value}"
         self.found = self.comparison_operator(value, self.expected_value)
 
     def set_expected_value(self, expected_value_string, eval_expected_value):

--- a/scenario_execution_ros/scenario_execution_ros/lib_osc/ros.osc
+++ b/scenario_execution_ros/scenario_execution_ros/lib_osc/ros.osc
@@ -137,6 +137,13 @@ action ros_launch:
     wait_for_shutdown: bool = true       # if true, the action waits until the execution has finished
     shutdown_timeout: time = 10s         # (only used if wait_for_shutdown is false) time to wait between SIGINT and SIGKILL getting sent, if process is still running on scenario shutdown
 
+action ros_run:
+    # Run a package specific executable
+    package_name: string                 # package that contains the executable
+    executable_name: string              # name of executable
+    wait_for_shutdown: bool = true       # if true, the action waits until the execution has finished
+    shutdown_timeout: time = 10s         # (only used if wait_for_shutdown is false) time to wait between SIGINT and SIGKILL getting sent, if process is still running on scenario shutdown
+
 action service_call:
     # Call a ROS service and wait for the reply.
     service_name: string                 # name of the service to connect to

--- a/scenario_execution_ros/setup.py
+++ b/scenario_execution_ros/setup.py
@@ -63,6 +63,7 @@ setup(
             'differential_drive_robot.tf_close_to = scenario_execution_ros.actions.tf_close_to:TfCloseTo',
             'log_check = scenario_execution_ros.actions.ros_log_check:RosLogCheck',
             'ros_launch = scenario_execution_ros.actions.ros_launch:RosLaunch',
+            'ros_run = scenario_execution_ros.actions.ros_run:RosRun',
             'service_call = scenario_execution_ros.actions.ros_service_call:RosServiceCall',
             'set_node_parameter = scenario_execution_ros.actions.ros_set_node_parameter:RosSetNodeParameter',
             'topic_monitor = scenario_execution_ros.actions.ros_topic_monitor:RosTopicMonitor',


### PR DESCRIPTION


Before, only the executed process itself got shut down on exit, leaving other spawned processes as zombies.
By sending the signal to all processes of a process group this bug is fixed.

Additionally a ros_run action is added.
