### PR TITLE
wait for simulation to come up

### DIFF
--- a/examples/example_nav2/package.xml
+++ b/examples/example_nav2/package.xml
@@ -13,6 +13,7 @@
 
   <depend>scenario_execution_ros</depend>
   <depend>scenario_execution_nav2</depend>
+  <depend>scenario_execution_gazebo</depend>
   <depend>nav2_bringup</depend>
 
   <exec_depend>rclpy</exec_depend>

--- a/examples/example_nav2/scenarios/example_nav2.osc
+++ b/examples/example_nav2/scenarios/example_nav2.osc
@@ -1,10 +1,12 @@
 import osc.helpers
 import osc.ros
 import osc.nav2
+import osc.gazebo
 
 scenario example_nav2:
     timeout(60s)
     robot: differential_drive_robot
     do serial:
+        wait_for_sim(world_name: 'depot')
         robot.init_nav2(pose_3d(position_3d(x: 0.0m, y: 0.0m)))
         robot.nav_to_pose(pose_3d(position_3d(x: 3.0m, y: -3.0m)))


### PR DESCRIPTION
example_nav2 does not succeed in github action because gazebo segfaults. Reduce initial load by waiting for the simulation before initializing nav2.