### PR TITLE
add ability to set snapshot period

### DIFF
--- a/docs/how_to_run.rst
+++ b/docs/how_to_run.rst
@@ -30,7 +30,8 @@ Runtime Parameters
      - (For debugging) Show current state of py tree
    * - ``--post-run POST_RUN_COMMAND``
      - Command or script to run after scenario execution. The command will be called as ``<command> <output_dir>``. Example: ``--post-run ./post.sh``
-
+   * - ``--snapshot-period SNAPSHOT_PERIOD``
+     - How often (in seconds) to publish behavior tree snapshots to ``/scenario_execution/snapshots``. Default: only on status change. Set to a float value (e.g. ``--snapshot-period 1.0`` for every second).
 
 Run locally with ROS2
 ---------------------

--- a/scenario_execution/scenario_execution/scenario_execution_base.py
+++ b/scenario_execution/scenario_execution/scenario_execution_base.py
@@ -422,7 +422,7 @@ def main():
     """
     main function
     """
-    args = ScenarioExecution.get_arg_parser().parse_known_args(sys.argv[1:])
+    args, _ = ScenarioExecution.get_arg_parser().parse_known_args(sys.argv[1:])
     try:
         scenario_execution = ScenarioExecution(debug=args.debug,
                                                log_model=args.log_model,

--- a/scenario_execution/scenario_execution/scenario_execution_base.py
+++ b/scenario_execution/scenario_execution/scenario_execution_base.py
@@ -400,7 +400,7 @@ class ScenarioExecution(object):
                                            failure_output=failure_output))
 
     @staticmethod
-    def parse_args(args):
+    def get_arg_parser():
         parser = argparse.ArgumentParser()
         parser.add_argument('-d', '--debug', action='store_true', help='debugging output')
         parser.add_argument('-l', '--log-model', action='store_true',
@@ -415,15 +415,14 @@ class ScenarioExecution(object):
                             help='File specifying scenario parameter. These will override default values.')
         parser.add_argument('--post-run', type=str, help='Command to run after scenario execution (expected commandline: <command> <output_dir>)')
         parser.add_argument('scenario', type=str, help='scenario file to execute', nargs='?')
-        args, _ = parser.parse_known_args(args)
-        return args
+        return parser
 
 
 def main():
     """
     main function
     """
-    args = ScenarioExecution.parse_args(sys.argv[1:])
+    args = ScenarioExecution.get_arg_parser().parse_known_args(sys.argv[1:])
     try:
         scenario_execution = ScenarioExecution(debug=args.debug,
                                                log_model=args.log_model,

--- a/scenario_execution_ros/scenario_execution_ros/scenario_execution_ros.py
+++ b/scenario_execution_ros/scenario_execution_ros/scenario_execution_ros.py
@@ -36,7 +36,10 @@ class ROSScenarioExecution(ScenarioExecution):
 
         # parse from commandline
         args_without_ros = rclpy.utilities.remove_ros_args(sys.argv[1:])
-        args = ScenarioExecution.parse_args(args_without_ros)
+        arg_parser = ScenarioExecution.get_arg_parser()
+        arg_parser.add_argument('--snapshot-period', type=float, help='How often to publish behavior tree snapshots (default: only on status change)', default=sys.float_info.max)
+        args, _ = arg_parser.parse_known_args(args_without_ros)
+    
         debug = args.debug
         log_model = args.log_model
         live_tree = args.live_tree
@@ -46,6 +49,7 @@ class ROSScenarioExecution(ScenarioExecution):
         self.render_dot = args.dot
         self.scenario_parameter_file = args.scenario_parameter_file
         self.post_run = args.post_run
+        self.snapshot_period = args.snapshot_period
 
         # override commandline by ros parameters
         self.node.declare_parameter('debug', False)
@@ -57,6 +61,7 @@ class ROSScenarioExecution(ScenarioExecution):
         self.node.declare_parameter('dot', False)
         self.node.declare_parameter('scenario_parameter_file', "")
         self.node.declare_parameter('post_run', "")
+        self.node.declare_parameter('snapshot_period', 1.0)
 
         if self.node.get_parameter('debug').value:
             debug = self.node.get_parameter('debug').value
@@ -76,6 +81,8 @@ class ROSScenarioExecution(ScenarioExecution):
             self.scenario_parameter_file = self.node.get_parameter('scenario_parameter_file').value
         if self.node.get_parameter('post_run').value:
             self.post_run = self.node.get_parameter('post_run').value
+        if self.node.get_parameter('snapshot_period').value:
+            self.snapshot_period = self.node.get_parameter('snapshot_period').value
         self.logger = RosLogger('scenario_execution_ros', debug)
         super().__init__(debug=debug,
                          log_model=log_model,
@@ -104,7 +111,7 @@ class ROSScenarioExecution(ScenarioExecution):
     def post_setup(self):
         request = OpenSnapshotStream.Request()
         request.topic_name = "/scenario_execution/snapshots"
-        request.parameters.snapshot_period = sys.float_info.max
+        request.parameters.snapshot_period = self.snapshot_period
         request.parameters.blackboard_data = True
         response = OpenSnapshotStream.Response()
         self.behaviour_tree._open_snapshot_stream(request, response)  # pylint: disable=protected-access

--- a/scenario_execution_ros/scenario_execution_ros/scenario_execution_ros.py
+++ b/scenario_execution_ros/scenario_execution_ros/scenario_execution_ros.py
@@ -39,7 +39,7 @@ class ROSScenarioExecution(ScenarioExecution):
         arg_parser = ScenarioExecution.get_arg_parser()
         arg_parser.add_argument('--snapshot-period', type=float, help='How often to publish behavior tree snapshots (default: only on status change)', default=sys.float_info.max)
         args, _ = arg_parser.parse_known_args(args_without_ros)
-    
+
         debug = args.debug
         log_model = args.log_model
         live_tree = args.live_tree


### PR DESCRIPTION
By default, behavior tree snapshots are only published on status change.
If you're interested in the current feedback message, set `--snapshot-period` to e.g. 1 to receive updates every second.