### PR TITLE
Allow overriding non-initialized parameters

### DIFF
--- a/docs/libraries.rst
+++ b/docs/libraries.rst
@@ -331,7 +331,7 @@ Spawn multiple actors within simulation at once.
 Each ``spawn_entity`` in the ``entities`` list has the following structure:
     
     - ``entity_name``: Name of the entity in simulation (string)
-    - ``pose``: Position and orientation where the object gets spawned (pose_3d)
+    - ``spawn_pose``: Position and orientation where the object gets spawned (pose_3d)
     - ``model``: Model definition (string) - supports the same formats as ``osc_object.spawn()``
     - ``xacro_arguments``: Optional comma-separated list of argument key:=value pairs (string)
 

--- a/libs/scenario_execution_gazebo/scenario_execution_gazebo/lib_osc/gazebo.osc
+++ b/libs/scenario_execution_gazebo/scenario_execution_gazebo/lib_osc/gazebo.osc
@@ -29,7 +29,7 @@ action osc_actor.spawn:
 
 struct spawn_entity:
     entity_name: string                 # name of entity in simulation
-    pose: pose_3d                       # position at which the object gets spawned
+    spawn_pose: pose_3d                 # position at which the object gets spawned
     model: string                       # model definition
     xacro_arguments: string = ''        # comma-separated list of argument key:=value pairs
 

--- a/scenario_execution/scenario_execution/model/osc2_parser.py
+++ b/scenario_execution/scenario_execution/model/osc2_parser.py
@@ -272,6 +272,15 @@ class OpenScenario2Parser(object):
 
                             self.create_override_value_function_application(funct_app, type_def, list(
                                 param_override_val.keys()), param_override_val)
+                        elif val is None and isinstance(param_override_val, str):
+                            literal = StringLiteral(param_override_val)
+                            arg.set_children(literal)
+                        elif val is None and isinstance(param_override_val, float):
+                            literal = FloatLiteral(param_override_val)
+                            arg.set_children(literal)
+                        elif val is None and isinstance(param_override_val, int):
+                            literal = IntegerLiteral("int", param_override_val)
+                            arg.set_children(literal)
                         else:
                             raise ValueError(f"Parameter {param.name} does not match override {param_override_val}")
 


### PR DESCRIPTION
+ fix naming in gazebo lib