### PR TITLE
variable parent frame in tf_close_to action

### DIFF
--- a/docs/libraries.rst
+++ b/docs/libraries.rst
@@ -1732,6 +1732,10 @@ Wait until a TF frame is close to a defined reference point.
      - ``position_3d``
      -
      - Reference point to measure to distance to (z is not considered)
+   * - ``parent_frame_id``
+     - ``string``
+     - ``map``
+     - Defines the TF parent/reference frame id
    * - ``robot_frame_id``
      - ``string``
      - ``base_link``
@@ -1739,7 +1743,7 @@ Wait until a TF frame is close to a defined reference point.
    * - ``sim``
      - ``bool``
      - ``false``
-     - In simulation, we need to look up the transform map --> base_link at a different time as the scenario execution node is not allowed to use the sim time
+     - In simulation, we need to look up the transform parent_frame_id --> robot_frame_id at a different time as the scenario execution node is not allowed to use the sim time
    * - ``namespace_override``
      - ``string``
      - ``''``

--- a/scenario_execution_ros/scenario_execution_ros/actions/tf_close_to.py
+++ b/scenario_execution_ros/scenario_execution_ros/actions/tf_close_to.py
@@ -90,8 +90,7 @@ class TfCloseTo(BaseAction):
             raise ActionError(error_message, action=self) from e
 
         self.reference_point = (float(self.reference_point['x']), float(self.reference_point['y']))
-        self.feedback_message = f"Waiting for transform {
-            self.parent_frame_id} --> {self.robot_frame_id}"  # pylint: disable= attribute-defined-outside-init
+        self.feedback_message = f"Waiting for transform {self.parent_frame_id} --> {self.robot_frame_id}"  # pylint: disable= attribute-defined-outside-init
         self.tf_buffer = Buffer()
         tf_prefix = self.namespace
         if not tf_prefix.startswith('/') and tf_prefix != '':
@@ -124,8 +123,7 @@ class TfCloseTo(BaseAction):
         """
         translation, success = self.get_translation_from_tf()
         if not success:
-            self.feedback_message = f"the pose of {
-                self.robot_frame_id} could not be retrieved from tf"  # pylint: disable= attribute-defined-outside-init
+            self.feedback_message = f"the pose of {self.robot_frame_id} could not be retrieved from tf"  # pylint: disable= attribute-defined-outside-init
             return Status.RUNNING
         dist = self.euclidean_dist(translation)
         marker = self.marker_handler.get_marker(self.marker_id)
@@ -138,8 +136,7 @@ class TfCloseTo(BaseAction):
             self.marker_handler.update_marker(self.marker_id, marker)
             return Status.SUCCESS
         else:
-            self.feedback_message = f"{self.robot_frame_id} has not reached point (distance={
-                dist-self.threshold:.2f})"  # pylint: disable= attribute-defined-outside-init
+            self.feedback_message = f"{self.robot_frame_id} has not reached point (distance={dist-self.threshold:.2f})"  # pylint: disable= attribute-defined-outside-init
             marker.color.r = 1.0
             marker.color.g = 1.0
             marker.color.b = 0.0
@@ -150,11 +147,9 @@ class TfCloseTo(BaseAction):
         t = None
         try:
             t = self.tf_buffer.lookup_transform(self.parent_frame_id, self.robot_frame_id, rclpy.time.Time())
-            self.feedback_message = f"Transform {
-                self.parent_frame_id} -> {self.robot_frame_id} got available."  # pylint: disable= attribute-defined-outside-init
+            self.feedback_message = f"Transform {self.parent_frame_id} -> {self.robot_frame_id} got available."  # pylint: disable= attribute-defined-outside-init
         except TransformException as e:
-            self.feedback_message = f"Could not transform {self.parent_frame_id} to {
-                self.robot_frame_id}"  # pylint: disable= attribute-defined-outside-init
+            self.feedback_message = f"Could not transform {self.parent_frame_id} to {self.robot_frame_id}"  # pylint: disable= attribute-defined-outside-init
             self.node.get_logger().warn(
                 f'Could not transform {self.parent_frame_id} to {self.robot_frame_id}: {e}')
             return None, False

--- a/scenario_execution_ros/scenario_execution_ros/actions/tf_close_to.py
+++ b/scenario_execution_ros/scenario_execution_ros/actions/tf_close_to.py
@@ -90,7 +90,8 @@ class TfCloseTo(BaseAction):
             raise ActionError(error_message, action=self) from e
 
         self.reference_point = (float(self.reference_point['x']), float(self.reference_point['y']))
-        self.feedback_message = f"Waiting for transform {self.parent_frame_id} --> {self.robot_frame_id}"  # pylint: disable= attribute-defined-outside-init
+        self.feedback_message = f"Waiting for transform {
+            self.parent_frame_id} --> {self.robot_frame_id}"  # pylint: disable= attribute-defined-outside-init
         self.tf_buffer = Buffer()
         tf_prefix = self.namespace
         if not tf_prefix.startswith('/') and tf_prefix != '':
@@ -123,7 +124,8 @@ class TfCloseTo(BaseAction):
         """
         translation, success = self.get_translation_from_tf()
         if not success:
-            self.feedback_message = f"the pose of {self.robot_frame_id} could not be retrieved from tf"  # pylint: disable= attribute-defined-outside-init
+            self.feedback_message = f"the pose of {
+                self.robot_frame_id} could not be retrieved from tf"  # pylint: disable= attribute-defined-outside-init
             return Status.RUNNING
         dist = self.euclidean_dist(translation)
         marker = self.marker_handler.get_marker(self.marker_id)
@@ -136,7 +138,8 @@ class TfCloseTo(BaseAction):
             self.marker_handler.update_marker(self.marker_id, marker)
             return Status.SUCCESS
         else:
-            self.feedback_message = f"{self.robot_frame_id} has not reached point (distance={dist-self.threshold:.2f})"  # pylint: disable= attribute-defined-outside-init
+            self.feedback_message = f"{self.robot_frame_id} has not reached point (distance={
+                dist-self.threshold:.2f})"  # pylint: disable= attribute-defined-outside-init
             marker.color.r = 1.0
             marker.color.g = 1.0
             marker.color.b = 0.0
@@ -147,9 +150,11 @@ class TfCloseTo(BaseAction):
         t = None
         try:
             t = self.tf_buffer.lookup_transform(self.parent_frame_id, self.robot_frame_id, rclpy.time.Time())
-            self.feedback_message = f"Transform {self.parent_frame_id} -> {self.robot_frame_id} got available."  # pylint: disable= attribute-defined-outside-init
+            self.feedback_message = f"Transform {
+                self.parent_frame_id} -> {self.robot_frame_id} got available."  # pylint: disable= attribute-defined-outside-init
         except TransformException as e:
-            self.feedback_message = f"Could not transform {self.parent_frame_id} to {self.robot_frame_id}"  # pylint: disable= attribute-defined-outside-init
+            self.feedback_message = f"Could not transform {self.parent_frame_id} to {
+                self.robot_frame_id}"  # pylint: disable= attribute-defined-outside-init
             self.node.get_logger().warn(
                 f'Could not transform {self.parent_frame_id} to {self.robot_frame_id}: {e}')
             return None, False

--- a/scenario_execution_ros/scenario_execution_ros/actions/tf_close_to.py
+++ b/scenario_execution_ros/scenario_execution_ros/actions/tf_close_to.py
@@ -172,4 +172,3 @@ class TfCloseTo(BaseAction):
         self.marker_handler.remove_markers([self.marker_id])
         if self.tf_listener:
             del self.tf_listener
-

--- a/scenario_execution_ros/scenario_execution_ros/actions/tf_close_to.py
+++ b/scenario_execution_ros/scenario_execution_ros/actions/tf_close_to.py
@@ -42,6 +42,7 @@ class TfCloseTo(BaseAction):
         threshold: float,
         sim: bool,
         robot_frame_id: str,
+        parent_frame_id: str = 'map',
     ):
         super().__init__()
 
@@ -56,7 +57,7 @@ class TfCloseTo(BaseAction):
         self.reference_point = reference_point
         self.threshold = threshold
         self.sim = sim
-
+        self.parent_frame_id = parent_frame_id
         if robot_frame_id:
             self.robot_frame_id = robot_frame_id
         else:
@@ -89,7 +90,7 @@ class TfCloseTo(BaseAction):
             raise ActionError(error_message, action=self) from e
 
         self.reference_point = (float(self.reference_point['x']), float(self.reference_point['y']))
-        self.feedback_message = f"Waiting for transform map --> base_link"  # pylint: disable= attribute-defined-outside-init
+        self.feedback_message = f"Waiting for transform {self.parent_frame_id} --> {self.robot_frame_id}"  # pylint: disable= attribute-defined-outside-init
         self.tf_buffer = Buffer()
         tf_prefix = self.namespace
         if not tf_prefix.startswith('/') and tf_prefix != '':
@@ -102,7 +103,7 @@ class TfCloseTo(BaseAction):
         )
 
         marker = Marker()
-        marker.header.frame_id = 'map'
+        marker.header.frame_id = self.parent_frame_id
         marker.type = Marker.CYLINDER
         marker.scale.x = self.threshold
         marker.scale.y = self.threshold
@@ -145,12 +146,12 @@ class TfCloseTo(BaseAction):
     def get_translation_from_tf(self):
         t = None
         try:
-            t = self.tf_buffer.lookup_transform('map', self.robot_frame_id, rclpy.time.Time())
-            self.feedback_message = f"Transform map -> base_link got available."  # pylint: disable= attribute-defined-outside-init
+            t = self.tf_buffer.lookup_transform(self.parent_frame_id, self.robot_frame_id, rclpy.time.Time())
+            self.feedback_message = f"Transform {self.parent_frame_id} -> {self.robot_frame_id} got available."  # pylint: disable= attribute-defined-outside-init
         except TransformException as e:
-            self.feedback_message = f"Could not transform map to base_link"  # pylint: disable= attribute-defined-outside-init
+            self.feedback_message = f"Could not transform {self.parent_frame_id} to {self.robot_frame_id}"  # pylint: disable= attribute-defined-outside-init
             self.node.get_logger().warn(
-                f'Could not transform map to base_link: {e}')
+                f'Could not transform {self.parent_frame_id} to {self.robot_frame_id}: {e}')
             return None, False
 
         return t.transform.translation, True

--- a/scenario_execution_ros/scenario_execution_ros/actions/tf_close_to.py
+++ b/scenario_execution_ros/scenario_execution_ros/actions/tf_close_to.py
@@ -172,3 +172,4 @@ class TfCloseTo(BaseAction):
         self.marker_handler.remove_markers([self.marker_id])
         if self.tf_listener:
             del self.tf_listener
+

--- a/scenario_execution_ros/scenario_execution_ros/lib_osc/ros.osc
+++ b/scenario_execution_ros/scenario_execution_ros/lib_osc/ros.osc
@@ -126,8 +126,9 @@ action differential_drive_robot.tf_close_to:
     # Wait until a TF frame is close to a defined reference point
     threshold: length                    # distance at which the action succeeds
     reference_point: position_3d         # z is not considered
+    parent_frame_id: string = 'map'      # defines the TF parent frame id of the robot. Defaults to map.
     robot_frame_id: string = 'base_link' # defines the TF frame id of the robot 
-    sim: bool = false                    # in simulation, we need to look up the transform map --> base_link at a different time as the scenario execution node is not allowed to use the sim time
+    sim: bool = false                    # in simulation, we need to look up the transform parent_frame_id --> robot_frame_id at a different time as the scenario execution node is not allowed to use the sim time
     namespace_override: string = ''      # if set, it's used as namespace (instead of the associated actor's name)
 
 action log_check:

--- a/scenario_execution_ros/scenario_execution_ros/lib_osc/ros.osc
+++ b/scenario_execution_ros/scenario_execution_ros/lib_osc/ros.osc
@@ -126,10 +126,10 @@ action differential_drive_robot.tf_close_to:
     # Wait until a TF frame is close to a defined reference point
     threshold: length                    # distance at which the action succeeds
     reference_point: position_3d         # z is not considered
-    parent_frame_id: string = 'map'      # defines the TF parent frame id of the robot. Defaults to map.
     robot_frame_id: string = 'base_link' # defines the TF frame id of the robot 
     sim: bool = false                    # in simulation, we need to look up the transform parent_frame_id --> robot_frame_id at a different time as the scenario execution node is not allowed to use the sim time
     namespace_override: string = ''      # if set, it's used as namespace (instead of the associated actor's name)
+    parent_frame_id: string = 'map'      # defines the TF parent frame id of the robot. Defaults to map.
 
 action log_check:
     # Check the ROS log for specific output

--- a/scenario_execution_ros/scenario_execution_ros/marker_handler.py
+++ b/scenario_execution_ros/scenario_execution_ros/marker_handler.py
@@ -33,7 +33,8 @@ class MarkerHandler(object):
         self.marker_publisher = self.node.create_publisher(Marker, '/scenario_marker', 5)
 
     def add_marker(self, marker: Marker):
-        marker.header.frame_id = 'map'
+        if not marker.header.frame_id:
+            marker.header.frame_id = 'map'
         marker.action = marker.ADD
         self.markers.append(marker)
 
@@ -54,7 +55,8 @@ class MarkerHandler(object):
     def update_marker(self, marker_id, marker):
         self.markers[marker_id] = marker
         self.markers[marker_id].id = marker_id
-        self.markers[marker_id].header.frame_id = 'map'
+        if not self.markers[marker_id].header.frame_id:
+            self.markers[marker_id].header.frame_id = 'map'
         self.markers[marker_id].action = marker.MODIFY
 
         self.marker_publisher.publish(self.markers[marker_id])

--- a/scenario_execution_ros/test/test_tf_close_to.py
+++ b/scenario_execution_ros/test/test_tf_close_to.py
@@ -1,0 +1,175 @@
+# Copyright (C) 2026 Frederik Pasch
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+import unittest
+from unittest.mock import ANY, Mock, patch
+
+from antlr4.InputStream import InputStream
+import py_trees
+
+from scenario_execution.get_osc_library import (
+    get_helpers_library,
+    get_robotics_library,
+    get_standard_library,
+    get_types_library,
+)
+from scenario_execution.model.model_to_py_tree import create_py_tree
+from scenario_execution.model.osc2_parser import OpenScenario2Parser
+from scenario_execution.utils.logging import Logger
+from scenario_execution_ros.actions.tf_close_to import TfCloseTo
+from scenario_execution_ros.get_osc_library import get_ros_library
+from scenario_execution_ros.marker_handler import MarkerHandler
+
+
+class PublisherStub:
+
+    def __init__(self):
+        self.messages = []
+
+    def publish(self, msg):
+        self.messages.append(msg)
+
+
+class EntryPointStub:
+
+    def __init__(self, name, load_value, module_name="test"):
+        self.name = name
+        self.load_value = load_value
+        self.module_name = module_name
+
+    def load(self):
+        return self.load_value
+
+
+class NodeStub:
+
+    def __init__(self):
+        self.publisher = PublisherStub()
+
+    def create_publisher(self, *_args, **_kwargs):
+        return self.publisher
+
+
+class TestTfCloseTo(unittest.TestCase):
+
+    def entry_points(self, group):
+        if group == "scenario_execution.osc_libraries":
+            return [
+                EntryPointStub("helpers", get_helpers_library),
+                EntryPointStub("robotics", get_robotics_library),
+                EntryPointStub("ros", get_ros_library),
+                EntryPointStub("standard", get_standard_library),
+                EntryPointStub("types", get_types_library),
+            ]
+        if group == "scenario_execution.actions":
+            return [
+                EntryPointStub(
+                    "differential_drive_robot.tf_close_to",
+                    TfCloseTo,
+                    "scenario_execution_ros.actions.tf_close_to",
+                )
+            ]
+        return []
+
+    def build_action(self, scenario_content):
+        parser = OpenScenario2Parser(Logger("test", False))
+        tree = py_trees.composites.Sequence(name="", memory=True)
+        parsed_tree = parser.parse_input_stream(InputStream(scenario_content))
+        with patch(
+            "scenario_execution.model.model_builder.entry_points",
+            self.entry_points,
+        ):
+            model = parser.create_internal_model(parsed_tree, tree, "test.osc", False)
+        with patch(
+            "scenario_execution.model.model_to_py_tree.entry_points",
+            self.entry_points,
+        ):
+            tree = create_py_tree(model, tree, parser.logger, False)
+
+        for node in tree.iterate():
+            if isinstance(node, TfCloseTo):
+                return node
+        self.fail("TfCloseTo action not found in parsed scenario")
+
+    def test_defaults_to_map_parent_frame(self):
+        scenario_content = (
+            "import osc.ros\n"
+            "scenario test_tf_close_to_default_parent_frame:\n"
+            "    robot: differential_drive_robot\n"
+            "    do serial:\n"
+            "        robot.tf_close_to(\n"
+            "            reference_point: position_3d(x: 1.0m, y: 2.0m),\n"
+            "            threshold: 0.4m)\n"
+        )
+
+        action = self.build_action(scenario_content)
+
+        self.assertEqual("map", action.parent_frame_id)
+        self.assertEqual("base_link", action.robot_frame_id)
+
+    def test_uses_custom_parent_frame_for_lookup_and_marker(self):
+        node = NodeStub()
+        marker_handler = MarkerHandler(node)
+        action = TfCloseTo(
+            associated_actor={"namespace": ""},
+            namespace_override="",
+            reference_point={"x": 1.0, "y": 2.0},
+            threshold=0.4,
+            sim=False,
+            robot_frame_id="base_link",
+            parent_frame_id="odom",
+        )
+
+        with patch("scenario_execution_ros.actions.tf_close_to.Buffer"):
+            with patch(
+                "scenario_execution_ros.actions.tf_close_to.NamespacedTransformListener"
+            ):
+                action.setup(node=node, marker_handler=marker_handler)
+
+        marker = marker_handler.get_marker(action.marker_id)
+        self.assertEqual("odom", marker.header.frame_id)
+
+        transform = Mock()
+        transform.transform.translation = Mock()
+        action.tf_buffer = Mock()
+        action.tf_buffer.lookup_transform.return_value = transform
+        action.node = Mock()
+
+        translation, success = action.get_translation_from_tf()
+
+        self.assertTrue(success)
+        self.assertIs(translation, transform.transform.translation)
+        action.tf_buffer.lookup_transform.assert_called_once_with("odom", "base_link", ANY)
+
+    def test_parses_custom_parent_frame_argument(self):
+        scenario_content = (
+            "import osc.ros\n"
+            "scenario test_tf_close_to_custom_parent_frame:\n"
+            "    robot: differential_drive_robot\n"
+            "    do serial:\n"
+            "        robot.tf_close_to(\n"
+            "            reference_point: position_3d(x: 1.0m, y: 2.0m),\n"
+            "            parent_frame_id: 'odom',\n"
+            "            threshold: 0.4m)\n"
+        )
+
+        action = self.build_action(scenario_content)
+
+        self.assertEqual("odom", action.parent_frame_id)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/scenario_execution_ros/test/test_tf_close_to.py
+++ b/scenario_execution_ros/test/test_tf_close_to.py
@@ -102,7 +102,7 @@ class TestTfCloseTo(unittest.TestCase):
         for node in tree.iterate():
             if isinstance(node, TfCloseTo):
                 return node
-        self.fail("TfCloseTo action not found in parsed scenario")
+        return self.fail("TfCloseTo action not found in parsed scenario")
 
     def test_defaults_to_map_parent_frame(self):
         scenario_content = (


### PR DESCRIPTION
<!-- For questions please refer to https://cps-test-lab.github.io/scenario-execution/development.html#contribute, mail to fred-labs@mailbox.org or ask in a comment below -->
### Description
Add new argument `parent_frame` to `tf_close_to` action to avoid the parent frame of the robot being hard-coded to `map`. This is particularly helpful when working with simulation environments without a map/localization and the ground-truth frame of the robot is located under a `world` coordinate frame.

### Pull request checklist
<!--  (Mark with "x") -->
- [ ] [Issue](https://github.com/cps-test-lab/scenario-execution/issues) created that explains the change and why it's needed
- [x] Tests are part of the PR (for bug fixes / features)
- [x] [Docs](https://cps-test-lab.github.io/scenario-execution/) reviewed and added / updated if needed (for bug fixes / features)
- [ ] Format and Lint checks (`make check`) pass locally
- [x] PR applies Apache 2.0 License to all code files

### Pull request type

<!-- Please do not submit updates to dependencies unless it fixes an issue. -->

<!-- Please limit your pull request to one type, submit multiple pull requests if needed. -->

<!--  (Mark one with "x") remove not chosen below -->

- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [x] Documentation changes
- [ ] Other (please describe)

### Current behavior
<!-- Please describe the current behavior that you are modifying, can be copied from relevant issue. -->
`tf_close_to` action can only locate robot frames in a tf-tree under map.

### New behavior
`tf_close_to` action has an argument to set the parent frame id

### How to test
Tests are part of the PR

