### PR TITLE
Feature/process log check

### DIFF
--- a/docs/libraries.rst
+++ b/docs/libraries.rst
@@ -662,6 +662,33 @@ If ``wait_for_shutdown`` is ``false`` and the process is still running on scenar
      - ``10s``
      - (Only used if ``wait_for_shutdown`` is ``false``) time to wait between ``shutdown_signal`` and SIGKILL getting sent, if process is still running on scenario shutdown
 
+``process_log_check()``
+^^^^^^^^^^^^^^^^^^^^^^^
+
+Wait for specific output captured from a process started by ``run_process``. The ``process_name`` parameter must match the label of a ``run_process`` invocation, e.g. ``app: run_process(...)`` can be checked with ``process_log_check('app', ['Ready'])``. If any entry within ``values`` is found, the action succeeds. If the process finishes and no matching output is found, the action fails.
+
+.. list-table::
+   :widths: 15 15 5 65
+   :header-rows: 1
+   :class: tight-table
+
+   * - Parameter
+     - Type
+     - Default
+     - Description
+   * - ``process_name``
+     - ``string``
+     -
+     - Label of the ``run_process`` action to inspect
+   * - ``values``
+     - ``list of string``
+     -
+     - List of strings to check for
+   * - ``from_start``
+     - ``bool``
+     - ``true``
+     - If false, only output emitted after this action starts is checked
+
 
 Kubernetes
 ----------

--- a/scenario_execution/scenario_execution/actions/process_log_check.py
+++ b/scenario_execution/scenario_execution/actions/process_log_check.py
@@ -1,0 +1,96 @@
+# Copyright (C) 2026 Frederik Pasch
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+import py_trees
+
+from scenario_execution.actions.base_action import BaseAction, ActionError
+
+
+class ProcessLogCheck(BaseAction):
+    """
+    Class for scanning the captured output of a process started by run_process.
+    """
+
+    def __init__(self):
+        super().__init__()
+        self.process_registry = None
+        self.process_name = None
+        self.values = None
+        self.from_start = True
+        self.process = None
+        self.start_index = 0
+        self.found = None
+
+    def setup(self, **kwargs):
+        try:
+            self.process_registry = kwargs['process_registry']
+        except KeyError as e:
+            error_message = "didn't find 'process_registry' in setup's kwargs [{}][{}]".format(
+                self.name, self.__class__.__name__)
+            raise ActionError(error_message, action=self) from e
+        self.feedback_message = "Waiting for process log"  # pylint: disable= attribute-defined-outside-init
+
+    def execute(self, process_name: str, values: list, from_start: bool = True):
+        self.process_name = process_name
+        self.values = values
+        self.from_start = from_start
+        self.process = None
+        self.start_index = 0
+        self.found = None
+
+    def update(self) -> py_trees.common.Status:
+        """
+        Wait for specified output in a run_process action.
+
+        return:
+            py_trees.common.Status if found
+        """
+        if self.found is None:
+            self.found = False
+            if not self._resolve_process():
+                return py_trees.common.Status.FAILURE
+            if not self.from_start:
+                self.start_index = len(self.process.get_output_snapshot())
+
+        output = self.process.get_output_snapshot()
+        for line in output[self.start_index:]:
+            for val in self.values:
+                if val in line:
+                    self.feedback_message = f"Found string '{val}' in '{line}'"  # pylint: disable= attribute-defined-outside-init
+                    self.found = True
+                    return py_trees.common.Status.SUCCESS
+
+        if self.process.is_output_complete():
+            self.feedback_message = f"No matching output found for process '{self.process_name}'"  # pylint: disable= attribute-defined-outside-init
+            return py_trees.common.Status.FAILURE
+
+        return py_trees.common.Status.RUNNING
+
+    def _resolve_process(self):
+        processes = self.process_registry.get(self.process_name)
+        if not processes:
+            self.feedback_message = f"No run_process action named '{self.process_name}' found"  # pylint: disable= attribute-defined-outside-init
+            self.logger.error(self.feedback_message)
+            return False
+
+        if len(processes) > 1:
+            self.feedback_message = (  # pylint: disable= attribute-defined-outside-init
+                f"Process name '{self.process_name}' is ambiguous; use a unique run_process label")
+            self.logger.error(self.feedback_message)
+            return False
+
+        self.process = processes[0]
+        return True

--- a/scenario_execution/scenario_execution/actions/process_log_check.py
+++ b/scenario_execution/scenario_execution/actions/process_log_check.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2026 Frederik Pasch
+# Copyright (C) 2026 Florian Mirus
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/scenario_execution/scenario_execution/actions/process_registry.py
+++ b/scenario_execution/scenario_execution/actions/process_registry.py
@@ -1,0 +1,28 @@
+# Copyright (C) 2026 Frederik Pasch
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+
+class ProcessRegistry:
+    """Per-scenario registry for processes started by run_process actions."""
+
+    def __init__(self):
+        self._processes = {}
+
+    def register(self, name, process):
+        self._processes.setdefault(name, []).append(process)
+
+    def get(self, name):
+        return self._processes.get(name, [])

--- a/scenario_execution/scenario_execution/actions/process_registry.py
+++ b/scenario_execution/scenario_execution/actions/process_registry.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2026 Frederik Pasch
+# Copyright (C) 2026 Florian Mirus
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/scenario_execution/scenario_execution/actions/run_process.py
+++ b/scenario_execution/scenario_execution/actions/run_process.py
@@ -16,7 +16,7 @@
 
 import py_trees  # pylint: disable=import-error
 import subprocess  # nosec B404
-from threading import Thread
+from threading import Thread, Lock
 from collections import deque
 import signal
 from scenario_execution.actions.base_action import BaseAction
@@ -39,6 +39,14 @@ class RunProcess(BaseAction):
         self.log_stdout_thread = None
         self.log_stderr_thread = None
         self.output = deque()
+        self.output_lock = Lock()
+        self.process_registry = None
+
+    def setup(self, **kwargs):
+        self.process_registry = kwargs.get('process_registry')
+        has_label = self._model is not None and self._model.name
+        if self.process_registry is not None and has_label:
+            self.process_registry.register(self.name, self)
 
     def execute(self, command=None, wait_for_shutdown=True, shutdown_timeout=10, shutdown_signal=("", signal.SIGTERM)):
         self.command = command.split(" ") if isinstance(command, str) else command
@@ -77,7 +85,8 @@ class RunProcess(BaseAction):
                         msg = line.decode().strip()
                         if log_fct:
                             log_fct(msg)
-                        buffer.append(msg)
+                        with self.output_lock:
+                            buffer.append(msg)
                     out.close()
                 except ValueError:
                     pass
@@ -147,6 +156,23 @@ class RunProcess(BaseAction):
         hook for subclassed
         """
         pass
+
+    def get_output_snapshot(self):
+        """
+        Return a non-mutating snapshot of the captured process output.
+        """
+        with self.output_lock:
+            return list(self.output)
+
+    def is_output_complete(self):
+        """
+        Return whether the process has finished and both output readers are done.
+        """
+        if self.process is None or self.process.poll() is None:
+            return False
+        stdout_done = self.log_stdout_thread is None or not self.log_stdout_thread.is_alive()
+        stderr_done = self.log_stderr_thread is None or not self.log_stderr_thread.is_alive()
+        return stdout_done and stderr_done
 
     def set_command(self, command):
         self.command = command

--- a/scenario_execution/scenario_execution/lib_osc/helpers.osc
+++ b/scenario_execution/scenario_execution/lib_osc/helpers.osc
@@ -34,6 +34,12 @@ action run_process:
     shutdown_signal: signal = signal!sigterm # (only used if wait_for_shutdown is false) signal that is sent if a process is still running on scenario shutdown
     shutdown_timeout: time = 10s         # (only used if wait_for_shutdown is false) time to wait between shutdown_signal and SIGKILL getting sent if process is still running on scenario shutdown
 
+action process_log_check:
+    # Check the captured output of a process started by run_process. If any entry within values is found, the action succeeds.
+    process_name: string                 # Label of the run_process action to inspect
+    values: list of string               # strings to check for. If any is found, action succeeds
+    from_start: bool = true              # if false, only output emitted after this action starts is checked
+
 struct common:
     def get_scenario_file_directory() -> string is external scenario_execution.external_methods.common.get_scenario_file_directory() # Returns the absolute path to the directory where the scenario file is located in.
     def get_output_directory() -> string is external scenario_execution.external_methods.common.get_output_directory() # Returns the absolute path to the output directory

--- a/scenario_execution/scenario_execution/scenario_execution_base.py
+++ b/scenario_execution/scenario_execution/scenario_execution_base.py
@@ -28,6 +28,7 @@ from scenario_execution.model.osc2_parser import OpenScenario2Parser
 from scenario_execution.utils.logging import Logger
 from scenario_execution.model.model_file_loader import ModelFileLoader
 from scenario_execution.simulation import SimulationClock
+from scenario_execution.actions.process_registry import ProcessRegistry
 from dataclasses import dataclass
 from xml.sax.saxutils import escape  # nosec B406 # escape is only used on an internally generated error string
 from timeit import default_timer as timer
@@ -218,6 +219,7 @@ class ScenarioExecution(object):
         self.scenarios_list = []
         self.output_result_per_scenario = output_result_per_scenario
         self.current_scenario_output_dir = None
+        self.process_registry = None
 
     def setup(self, scenario: py_trees.behaviour.Behaviour, current_output_dir=None, **kwargs) -> bool:
         """
@@ -238,6 +240,7 @@ class ScenarioExecution(object):
         self.current_scenario = scenario
         self.current_scenario_start = datetime.now()
         self.blackboard = scenario.attach_blackboard_client(name="MainBlackboardClient", namespace=scenario.name)
+        self.process_registry = ProcessRegistry()
 
         # Initialize end and fail events
         self.blackboard.register_key("end", access=py_trees.common.Access.WRITE)
@@ -259,12 +262,14 @@ class ScenarioExecution(object):
         input_dir = None
         if self.scenario_file:
             input_dir = os.path.dirname(self.scenario_file)
+        setup_kwargs = dict(kwargs)
+        setup_kwargs['process_registry'] = self.process_registry
         self.behaviour_tree.setup(timeout=self.setup_timeout,
                                   logger=self.logger,
                                   input_dir=input_dir,
                                   output_dir=effective_output_dir,
                                   tick_period=self.tick_period,
-                                  **kwargs)
+                                  **setup_kwargs)
         self.post_setup()
 
     def setup_behaviour_tree(self, tree):

--- a/scenario_execution/setup.py
+++ b/scenario_execution/setup.py
@@ -88,6 +88,7 @@ setup(
             'decrement = scenario_execution.actions.decrement:Decrement',
             'log = scenario_execution.actions.log:Log',
             'run_process = scenario_execution.actions.run_process:RunProcess',
+            'process_log_check = scenario_execution.actions.process_log_check:ProcessLogCheck',
         ],
         'scenario_execution.osc_libraries': [
             'helpers = scenario_execution.get_osc_library:get_helpers_library',

--- a/scenario_execution/test/test_process_log_check.py
+++ b/scenario_execution/test/test_process_log_check.py
@@ -1,0 +1,143 @@
+# Copyright (C) 2026 Frederik Pasch
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+import os
+import stat
+import tempfile
+import unittest
+
+import py_trees
+from antlr4.InputStream import InputStream
+
+from scenario_execution import ScenarioExecution
+from scenario_execution.model.model_to_py_tree import create_py_tree
+from scenario_execution.model.osc2_parser import OpenScenario2Parser
+from scenario_execution.utils.logging import Logger
+
+
+class TestProcessLogCheck(unittest.TestCase):
+    # pylint: disable=missing-function-docstring
+
+    def setUp(self) -> None:
+        self.parser = OpenScenario2Parser(Logger('test', False))
+        self.scenario_execution = ScenarioExecution(debug=False,
+                                                    log_model=False,
+                                                    live_tree=False,
+                                                    scenario_file='test',
+                                                    output_dir='',
+                                                    tick_period=0.01)
+        self.tree = py_trees.composites.Sequence(name="", memory=True)
+        self.tmp_files = []
+
+    def tearDown(self):
+        for filename in self.tmp_files:
+            try:
+                os.unlink(filename)
+            except FileNotFoundError:
+                pass
+
+    def execute(self, scenario_content):
+        parsed_tree = self.parser.parse_input_stream(InputStream(scenario_content))
+        model = self.parser.create_internal_model(parsed_tree, self.tree, "test.osc", False)
+        self.tree = create_py_tree(model, self.tree, self.parser.logger, False)
+        self.scenario_execution.scenarios_list = [(self.tree, {}, None)]
+        self.scenario_execution.run()
+
+    def create_script(self, content):
+        with tempfile.NamedTemporaryFile('w', delete=False) as script:
+            script.write('#!/bin/sh\n')
+            script.write(content)
+        self.tmp_files.append(script.name)
+        os.chmod(script.name, stat.S_IRUSR | stat.S_IWUSR | stat.S_IXUSR)
+        return script.name
+
+    def test_success_after_process_finished(self):
+        scenario_content = """
+import osc.types
+import osc.helpers
+
+scenario test_process_log_check:
+    timeout(5s)
+    do serial:
+        proc: run_process('printf READY')
+        process_log_check('proc', ['READY'])
+"""
+        self.execute(scenario_content)
+        self.assertTrue(self.scenario_execution.process_results())
+
+    def test_success_while_process_is_running(self):
+        script = self.create_script('echo READY\nsleep 10\n')
+        scenario_content = f"""
+import osc.types
+import osc.helpers
+
+scenario test_process_log_check:
+    do parallel:
+        proc: run_process('{script}', wait_for_shutdown: false, shutdown_timeout: 1s)
+        serial:
+            process_log_check('proc', ['READY'])
+            emit end
+        time_out: serial:
+            wait elapsed(5s)
+            emit fail
+"""
+        self.execute(scenario_content)
+        self.assertTrue(self.scenario_execution.process_results())
+
+    def test_failure_when_process_finishes_without_match(self):
+        scenario_content = """
+import osc.types
+import osc.helpers
+
+scenario test_process_log_check:
+    timeout(5s)
+    do serial:
+        proc: run_process('printf OTHER')
+        process_log_check('proc', ['READY'])
+"""
+        self.execute(scenario_content)
+        self.assertFalse(self.scenario_execution.process_results())
+
+    def test_failure_for_unknown_process(self):
+        scenario_content = """
+import osc.types
+import osc.helpers
+
+scenario test_process_log_check:
+    timeout(5s)
+    do serial:
+        process_log_check('unknown', ['READY'])
+"""
+        self.execute(scenario_content)
+        self.assertFalse(self.scenario_execution.process_results())
+
+    def test_failure_for_unlabeled_process(self):
+        scenario_content = """
+import osc.types
+import osc.helpers
+
+scenario test_process_log_check:
+    timeout(5s)
+    do serial:
+        run_process('printf READY')
+        process_log_check('run_process', ['READY'])
+"""
+        self.execute(scenario_content)
+        self.assertFalse(self.scenario_execution.process_results())
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/scenario_execution/test/test_process_log_check.py
+++ b/scenario_execution/test/test_process_log_check.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2026 Frederik Pasch
+# Copyright (C) 2026 Florian Mirus
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.


### PR DESCRIPTION
### Description

Adds a `process_log_check()` helper action that allows scenarios to wait for expected output from a labeled `run_process()` action.

Issue Number: #66 

### Pull request checklist

- [x] [Issue](https://github.com/cps-test-lab/scenario-execution/issues) created that explains the change and why it's needed
- [x] Tests are part of the PR (for bug fixes / features)
- [x] [Docs](https://cps-test-lab.github.io/scenario-execution/) reviewed and added / updated if needed (for bug fixes / features)
- [ ] Format and Lint checks (`make check`) pass locally
- [x] PR applies Apache 2.0 License to all code files

### Pull request type

- [x] Feature

### Current behavior

`run_process()` can start external commands and log their stdout/stderr, but scenarios cannot directly wait for or assert specific process output. This makes it difficult to synchronize scenario execution with external tools that signal readiness or state changes through their logs.

### New behavior

This PR adds `process_log_check(process_name, values, from_start: true)`.

The new action checks the captured stdout/stderr output of a labeled `run_process()` action and succeeds as soon as any configured string is found. It fails if the referenced process finishes without producing a matching line, if the process label cannot be resolved, or if the process label is ambiguous.

The implementation also adds a per-scenario process registry, thread-safe output snapshots for `run_process()`, OSC library wiring, package entry point registration, and documentation for the new helper action.

### How to test

Automated coverage is included in `scenario_execution/test/test_process_log_check.py`, covering:

- success after the process has finished
- success while the process is still running
- failure when the process finishes without a matching log line
- failure for an unknown process label
- failure for an unlabeled process