### PR TITLE
Tracing

### DIFF
--- a/docs/architecture.rst
+++ b/docs/architecture.rst
@@ -102,6 +102,22 @@ The :class:`WallClock <scenario_execution.WallClock>` is used as fallback when n
    │    sim.shutdown()                                   │
    └─────────────────────────────────────────────────────┘
 
+**Who owns the loop: base runner vs. ROS runner**
+
+The loop above belongs to the base runner, where the simulation drives everything and there is no
+``rclpy`` — which also means no ROS behavior can run in it. The ROS runner cannot adopt that shape,
+because the executor owns its loop. ``ROSScenarioExecution`` therefore steps the simulation *from
+inside* the spin loop instead, so the simulation advances alongside the ROS behaviors that drive it
+and a scenario can bring up a ROS stack against a step-based simulator. Stepping is paced to real
+time; a simulation that publishes ``/clock`` on ``step()`` becomes the time source and other nodes
+run ``use_sim_time``.
+
+The lifecycle differs accordingly. The base runner sets the simulation up and shuts it down once per
+run, whereas the ROS runner does it **per scenario** — each scenario already runs on its own node and
+executor, because ``py_trees_ros`` adopts the node it is given and destroys it on ``shutdown()``. A
+simulation whose ``setup()`` or ``reset()`` raises fails that one scenario and lets the remaining
+scenarios run, rather than aborting the file.
+
 **API alignment with ros-simulation/simulation_interfaces**
 
 The :class:`SimulationInterface <scenario_execution.SimulationInterface>` is conceptually aligned with the `ros-simulation/simulation_interfaces <https://github.com/ros-simulation/simulation_interfaces>`_ standard, making it straightforward to implement adapters for compliant simulators.
@@ -146,3 +162,24 @@ The writer takes a :class:`Clock <scenario_execution.Clock>` and calls ``now()``
 Records carry ``osc_file``/``osc_line``/``osc_column`` so a behavior can be traced back to the scenario that declared it. Model elements have always known this (``ModelElement.set_ctx`` stores it from the ANTLR context, and ``ActionError`` reports it), but only plugin actions kept a reference to their model — composites, decorators and the built-in behaviors are plain py_trees objects. ``ModelToPyTree.BehaviorInit.stamp_source`` therefore stamps every behavior it creates with ``osc_source``.
 
 For a modifier the stamp deliberately uses the *invocation* rather than the ``ModifierDeclaration``: built-in modifiers are declared in an imported library, so the declaration would point every ``timeout()`` in every scenario at the same line of ``helpers.osc``. The file is stored per behavior rather than once per run for the same reason — ``set_ctx`` records the file being parsed, so an imported ``.osc`` keeps its own name.
+
+Log Line Format
+---------------
+
+Both loggers available through ``kwargs['logger']`` emit the same line shape::
+
+   [LEVEL] [epoch] [name]: message
+
+``Logger`` (used by the base runner) and ``RosLogger`` (which delegates to ``rclpy``) are two
+implementations of one base class, so a scenario's own output used to be formatted differently
+depending on which middleware happened to be in use — the base logger printed ``[name] [LEVEL] msg``,
+with no timestamp at all. Placing a scenario's output in time therefore depended on the backend, and
+a log aggregator needed one grammar per runner instead of one.
+
+The ANSI color for warnings and errors wraps the *message* rather than the whole line, so the level
+marker stays at the start of the line where a parser anchored there can still find it.
+
+.. note::
+
+   This changes the output of the base runner. Anything parsing ``scenario_execution``'s ``stdout``
+   (as opposed to ``scenario_execution_ros``', which already had this shape) needs updating.

--- a/docs/architecture.rst
+++ b/docs/architecture.rst
@@ -107,3 +107,42 @@ The :class:`WallClock <scenario_execution.WallClock>` is used as fallback when n
 The :class:`SimulationInterface <scenario_execution.SimulationInterface>` is conceptually aligned with the `ros-simulation/simulation_interfaces <https://github.com/ros-simulation/simulation_interfaces>`_ standard, making it straightforward to implement adapters for compliant simulators.
 
 See :ref:`step_based_simulation` for usage instructions and a complete example.
+
+.. _behaviour_tree_status_log_internals:
+
+Behaviour Tree Status Log
+-------------------------
+
+``--bt-log`` writes ``behaviors.jsonl``, described for users under :ref:`behaviour_tree_status_log`. This section covers why it is built the way it is; ``scenario_execution/utils/bt_logger.py`` holds the implementation.
+
+**One writer for both runners**
+
+The writer lives in ``ScenarioExecution``, so ``ROSScenarioExecution`` inherits it rather than reimplementing it, and ``bt_logger.py`` imports nothing but the standard library and py_trees. Before this existed, behaviour-tree state could only be captured through ``py_trees_ros``' snapshot stream, which meant recording a ROS topic — so ``mode: base`` scenarios had no way to record it at all, and everyone else paid for a rosbag to get it.
+
+**A post-tick handler, not a visitor**
+
+``add_post_tick_handler`` hands over the whole ``BehaviourTree``, so the writer walks ``root.iterate()`` — the same traversal ``py_trees_ros`` uses. A visitor only sees the nodes a tick actually traversed, which would miss a node *invalidated* out of the visited path and could not notice a subtree inserted or pruned at runtime. Walking every node each tick is O(nodes) and cheap at realistic tree sizes, so there is no ``changed`` gate to get subtly wrong.
+
+A ``SnapshotVisitor`` is still attached, but only to fill ``is_active``: a node can hold ``SUCCESS`` from an earlier tick without being on the current path, so its status alone cannot answer whether this tick touched it.
+
+**Content follows py_trees_ros, cadence does not**
+
+The per-record fields mirror ``py_trees_ros_interfaces/Behaviour`` so a reader familiar with the ROS snapshots finds the same information. ``py_trees_ros`` republishes the *entire* tree on every snapshot, which is right for a transport whose subscribers may attach at any moment but would make a file grow by the tree size per tick. Instead the whole tree is written once at ``timestamp`` 0 and only status changes after that; the initial snapshot is what keeps never-executed branches in the file, so the tree is still fully reconstructable.
+
+Two of their fields are dropped and one is kept for a specific reason:
+
+- ``child_ids`` is replaced by ``child_index``, one integer instead of a list of UUIDs per record. It is what restores sibling order, which ``parent_id`` alone does not give.
+- ``current_child_id`` is dropped because ``tip_id`` already carries what it was needed for.
+- ``tip_id`` is kept even though it looks derivable. Recomputing py_trees' ``tip()`` needs each composite's ``current_child``, which is not logged, and statuses alone do not determine it for a ``memory=True`` sequence or a parallel.
+
+**Time source**
+
+The writer takes a :class:`Clock <scenario_execution.Clock>` and calls ``now()``, so ``timestamp`` is simulated time whenever one exists and monotonic time otherwise — zero-based either way, with the metadata record naming which applied.
+
+``ScenarioExecution.setup()`` resolves it as ``kwargs.get('sim_clock') or kwargs.get('clock')``. The ROS runner passes ``sim_clock=RosClock(node)`` rather than ``clock=``: ``clock`` is what ``ClockTimer``/``ClockTimeout`` read, so passing it there would retarget every scenario's timeouts from wall time to ``/clock``. That may well be the correct semantics under ``use_sim_time``, but it changes when timeouts fire and is a separate decision from recording a log.
+
+**Source locations**
+
+Records carry ``osc_file``/``osc_line``/``osc_column`` so a behaviour can be traced back to the scenario that declared it. Model elements have always known this (``ModelElement.set_ctx`` stores it from the ANTLR context, and ``ActionError`` reports it), but only plugin actions kept a reference to their model — composites, decorators and the built-in behaviours are plain py_trees objects. ``ModelToPyTree.BehaviorInit.stamp_source`` therefore stamps every behaviour it creates with ``osc_source``.
+
+For a modifier the stamp deliberately uses the *invocation* rather than the ``ModifierDeclaration``: built-in modifiers are declared in an imported library, so the declaration would point every ``timeout()`` in every scenario at the same line of ``helpers.osc``. The file is stored per behaviour rather than once per run for the same reason — ``set_ctx`` records the file being parsed, so an imported ``.osc`` keeps its own name.

--- a/docs/architecture.rst
+++ b/docs/architecture.rst
@@ -108,16 +108,16 @@ The :class:`SimulationInterface <scenario_execution.SimulationInterface>` is con
 
 See :ref:`step_based_simulation` for usage instructions and a complete example.
 
-.. _behaviour_tree_status_log_internals:
+.. _behavior_tree_status_log_internals:
 
-Behaviour Tree Status Log
--------------------------
+Behavior Tree Status Log
+------------------------
 
-``--bt-log`` writes ``behaviors.jsonl``, described for users under :ref:`behaviour_tree_status_log`. This section covers why it is built the way it is; ``scenario_execution/utils/bt_logger.py`` holds the implementation.
+``--bt-log`` writes ``behaviors.jsonl``, described for users under :ref:`behavior_tree_status_log`. This section covers why it is built the way it is; ``scenario_execution/utils/bt_logger.py`` holds the implementation.
 
 **One writer for both runners**
 
-The writer lives in ``ScenarioExecution``, so ``ROSScenarioExecution`` inherits it rather than reimplementing it, and ``bt_logger.py`` imports nothing but the standard library and py_trees. Before this existed, behaviour-tree state could only be captured through ``py_trees_ros``' snapshot stream, which meant recording a ROS topic — so ``mode: base`` scenarios had no way to record it at all, and everyone else paid for a rosbag to get it.
+The writer lives in ``ScenarioExecution``, so ``ROSScenarioExecution`` inherits it rather than reimplementing it, and ``bt_logger.py`` imports nothing but the standard library and py_trees. Before this existed, behavior-tree state could only be captured through ``py_trees_ros``' snapshot stream, which meant recording a ROS topic — so ``mode: base`` scenarios had no way to record it at all, and everyone else paid for a rosbag to get it.
 
 **A post-tick handler, not a visitor**
 
@@ -127,7 +127,7 @@ A ``SnapshotVisitor`` is still attached, but only to fill ``is_active``: a node 
 
 **Content follows py_trees_ros, cadence does not**
 
-The per-record fields mirror ``py_trees_ros_interfaces/Behaviour`` so a reader familiar with the ROS snapshots finds the same information. ``py_trees_ros`` republishes the *entire* tree on every snapshot, which is right for a transport whose subscribers may attach at any moment but would make a file grow by the tree size per tick. Instead the whole tree is written once at ``timestamp`` 0 and only status changes after that; the initial snapshot is what keeps never-executed branches in the file, so the tree is still fully reconstructable.
+The per-record fields mirror ``py_trees_ros_interfaces/Behaviour`` so a reader familiar with the ROS snapshots finds the same information. ``py_trees_ros`` republishes the *entire* tree on every snapshot, which is right for a transport whose subscribers may attach at any moment but would make a file grow by the tree size per tick. Instead the whole tree is written once at ``timestamp`` 0 and only status changes after that; the initial snapshot is what keeps never-executed branches in the file, so the tree can still be fully reconstructed.
 
 Two of their fields are dropped and one is kept for a specific reason:
 
@@ -143,6 +143,6 @@ The writer takes a :class:`Clock <scenario_execution.Clock>` and calls ``now()``
 
 **Source locations**
 
-Records carry ``osc_file``/``osc_line``/``osc_column`` so a behaviour can be traced back to the scenario that declared it. Model elements have always known this (``ModelElement.set_ctx`` stores it from the ANTLR context, and ``ActionError`` reports it), but only plugin actions kept a reference to their model — composites, decorators and the built-in behaviours are plain py_trees objects. ``ModelToPyTree.BehaviorInit.stamp_source`` therefore stamps every behaviour it creates with ``osc_source``.
+Records carry ``osc_file``/``osc_line``/``osc_column`` so a behavior can be traced back to the scenario that declared it. Model elements have always known this (``ModelElement.set_ctx`` stores it from the ANTLR context, and ``ActionError`` reports it), but only plugin actions kept a reference to their model — composites, decorators and the built-in behaviors are plain py_trees objects. ``ModelToPyTree.BehaviorInit.stamp_source`` therefore stamps every behavior it creates with ``osc_source``.
 
-For a modifier the stamp deliberately uses the *invocation* rather than the ``ModifierDeclaration``: built-in modifiers are declared in an imported library, so the declaration would point every ``timeout()`` in every scenario at the same line of ``helpers.osc``. The file is stored per behaviour rather than once per run for the same reason — ``set_ctx`` records the file being parsed, so an imported ``.osc`` keeps its own name.
+For a modifier the stamp deliberately uses the *invocation* rather than the ``ModifierDeclaration``: built-in modifiers are declared in an imported library, so the declaration would point every ``timeout()`` in every scenario at the same line of ``helpers.osc``. The file is stored per behavior rather than once per run for the same reason — ``set_ctx`` records the file being parsed, so an imported ``.osc`` keeps its own name.

--- a/docs/dictionary.txt
+++ b/docs/dictionary.txt
@@ -55,3 +55,7 @@ pybullet
 floorplan
 dsl
 distro
+ROS
+rosbag
+reimplementing
+retarget

--- a/docs/how_to_run.rst
+++ b/docs/how_to_run.rst
@@ -14,6 +14,8 @@ Runtime Parameters
      - Description
    * - ``-h`` ``--help``
      - show help message
+   * - ``--bt-log``
+     - Record behaviour status over time to ``<output-dir>/behaviors.jsonl``. Requires ``--output-dir``. See `Behaviour tree status log`_ for the file format.
    * - ``-d`` ``--debug``
      - (For debugging) print internal debugging output
    * - ``--dot``
@@ -359,6 +361,71 @@ With 2 scenarios and 2 override documents this yields 4 runs:
 The ``-<index>`` suffix is appended automatically when more than one document
 is present; with a single document names stay as defined in the ``.osc`` file.
 All results are written as separate ``<testcase>`` entries in ``test.xml``.
+
+.. _behaviour_tree_status_log:
+
+Behaviour tree status log
+-------------------------
+
+``--bt-log`` records how the behaviour tree progressed over time to
+``<output-dir>/behaviors.jsonl``. It works the same with and without ROS 2 and needs no
+middleware. ``--output-dir`` is required. How it is implemented is described under
+:ref:`behaviour_tree_status_log_internals`.
+
+The file is `JSON Lines <https://jsonlines.org>`__ — one JSON object per line, each complete
+in itself, so reading it is one ``json.loads`` per line with no state to carry and no join:
+
+.. code-block:: json
+
+   {"format":"behaviour_tree_log","version":1,"scenario":"demo","scenario_file":"/scenarios/demo.osc","scenario_sha256":"e175a753…","tick_period":0.1,"clock":"SimulationClock","py_trees":"2.4.0","started_at":"2026-08-06T09:14:22Z"}
+   {"timestamp":0.0,"behavior_id":"0f2b1d8c-…","parent_id":null,"child_index":null,"behavior_name":"demo","class_name":"py_trees.composites.Sequence","type":"SEQUENCE","additional_detail":"","status":"INVALID","feedback_message":"","is_active":false,"tip_id":null,"osc_file":"/scenarios/demo.osc","osc_line":3,"osc_column":0}
+   {"timestamp":0.1,"behavior_id":"0f2b1d8c-…","parent_id":null,"child_index":null,"behavior_name":"demo","class_name":"py_trees.composites.Sequence","type":"SEQUENCE","additional_detail":"","status":"RUNNING","feedback_message":"","is_active":true,"tip_id":"e5182a6f-…","osc_file":"/scenarios/demo.osc","osc_line":3,"osc_column":0}
+
+**Line 1** is the metadata record, recognisable by its ``format`` key: which scenario file was
+run and its SHA-256, the tick period, which clock ``timestamp`` came from, and the py_trees
+version.
+
+**The following lines** describe one behaviour each. Before the first tick, every node in the
+tree is written once at ``timestamp`` 0 with status ``INVALID``; afterwards a line is added
+whenever a behaviour's **status** changes. ``feedback_message`` is captured at that moment but
+does not itself trigger a line.
+
+Because the initial snapshot covers the whole tree, the structure and the state at any point
+in time can be reconstructed from the file alone, including branches that never executed.
+
+.. list-table::
+   :header-rows: 1
+   :class: tight-table
+
+   * - Field
+     - Description
+   * - ``timestamp``
+     - Seconds since the scenario started. Simulated time when a clock is available (``--simulation``, or ROS with ``use_sim_time``), otherwise monotonic time. The metadata record's ``clock`` field says which.
+   * - ``behavior_id``, ``parent_id``
+     - py_trees' own UUIDs. ``parent_id`` is ``null`` for the root.
+   * - ``child_index``
+     - Position among the parent's children, ``null`` for the root. Needed to restore the order of a sequence's children, which ``parent_id`` alone does not give.
+   * - ``behavior_name``, ``class_name``
+     - Name given on construction, and the fully qualified class.
+   * - ``type``
+     - ``SEQUENCE``, ``SELECTOR``, ``PARALLEL``, ``DECORATOR`` or ``BEHAVIOUR``.
+   * - ``additional_detail``
+     - Extra information about the node, e.g. a parallel's policy.
+   * - ``status``
+     - ``INVALID``, ``RUNNING``, ``SUCCESS`` or ``FAILURE``.
+   * - ``feedback_message``
+     - The behaviour's feedback message at that moment.
+   * - ``is_active``
+     - Whether the behaviour was traversed by the tick that produced this record.
+   * - ``tip_id``
+     - The behaviour that determined this subtree's status (py_trees' ``tip()``), so a failing root points straight at the action responsible. ``null`` on a leaf.
+   * - ``osc_file``, ``osc_line``, ``osc_column``
+     - Where the behaviour came from in the scenario source. The file is per record because an imported ``.osc`` keeps its own name. Line is 1-based, column 0-based. ``null`` for a behaviour with no source element, e.g. a subtree an action builds internally.
+   * - ``removed``
+     - Present and ``true`` only when a subtree was pruned at runtime; the record then carries just ``timestamp`` and ``behavior_id``.
+
+Records are flushed as they are written, so a scenario that is aborted or times out still
+leaves a readable file up to that point.
 
 .. _per_scenario_output_directories:
 

--- a/docs/how_to_run.rst
+++ b/docs/how_to_run.rst
@@ -556,3 +556,20 @@ simulation is active. No changes to the OSC scenario file are needed:
 Without a simulation interface the clock falls back to system wall-clock time,
 so existing scenarios continue to work unchanged.
 
+**Step-based simulation with the ROS runner**
+
+``--simulation`` works with both runners:
+
+* ``scenario_execution`` (non-ROS): the simulation drives the loop exclusively
+  (``run_with_simulation``); there is no rclpy, so ROS behaviours are unavailable.
+* ``scenario_execution_ros`` (ROS): the ROS spin loop additionally ticks
+  ``simulation.step()``, so a step-based simulation runs **alongside** the ROS
+  behaviours that drive it. This lets a scenario bring up and drive a ROS stack
+  while the simulation advances time. A simulation that publishes ``/clock``
+  becomes the time source (other nodes run ``use_sim_time``), and stepping is
+  paced to realtime (the pace can be removed for faster-than-realtime runs).
+
+  With the ROS runner, ``setup()``/``reset()``/``step()``/``shutdown()`` are
+  called **per scenario** (each scenario runs on its own ROS node), rather than
+  ``setup``/``shutdown`` once for the whole file as with the non-ROS runner.
+

--- a/docs/how_to_run.rst
+++ b/docs/how_to_run.rst
@@ -15,7 +15,7 @@ Runtime Parameters
    * - ``-h`` ``--help``
      - show help message
    * - ``--bt-log``
-     - Record behaviour status over time to ``<output-dir>/behaviors.jsonl``. Requires ``--output-dir``. See `Behaviour tree status log`_ for the file format.
+     - Record behavior status over time to ``<output-dir>/behaviors.jsonl``. Requires ``--output-dir``. See `Behavior tree status log`_ for the file format.
    * - ``-d`` ``--debug``
      - (For debugging) print internal debugging output
    * - ``--dot``
@@ -362,15 +362,15 @@ The ``-<index>`` suffix is appended automatically when more than one document
 is present; with a single document names stay as defined in the ``.osc`` file.
 All results are written as separate ``<testcase>`` entries in ``test.xml``.
 
-.. _behaviour_tree_status_log:
+.. _behavior_tree_status_log:
 
-Behaviour tree status log
--------------------------
+Behavior tree status log
+------------------------
 
-``--bt-log`` records how the behaviour tree progressed over time to
+``--bt-log`` records how the behavior tree progressed over time to
 ``<output-dir>/behaviors.jsonl``. It works the same with and without ROS 2 and needs no
 middleware. ``--output-dir`` is required. How it is implemented is described under
-:ref:`behaviour_tree_status_log_internals`.
+:ref:`behavior_tree_status_log_internals`.
 
 The file is `JSON Lines <https://jsonlines.org>`__ — one JSON object per line, each complete
 in itself, so reading it is one ``json.loads`` per line with no state to carry and no join:
@@ -381,13 +381,13 @@ in itself, so reading it is one ``json.loads`` per line with no state to carry a
    {"timestamp":0.0,"behavior_id":"0f2b1d8c-…","parent_id":null,"child_index":null,"behavior_name":"demo","class_name":"py_trees.composites.Sequence","type":"SEQUENCE","additional_detail":"","status":"INVALID","feedback_message":"","is_active":false,"tip_id":null,"osc_file":"/scenarios/demo.osc","osc_line":3,"osc_column":0}
    {"timestamp":0.1,"behavior_id":"0f2b1d8c-…","parent_id":null,"child_index":null,"behavior_name":"demo","class_name":"py_trees.composites.Sequence","type":"SEQUENCE","additional_detail":"","status":"RUNNING","feedback_message":"","is_active":true,"tip_id":"e5182a6f-…","osc_file":"/scenarios/demo.osc","osc_line":3,"osc_column":0}
 
-**Line 1** is the metadata record, recognisable by its ``format`` key: which scenario file was
+**Line 1** is the metadata record, recognizable by its ``format`` key: which scenario file was
 run and its SHA-256, the tick period, which clock ``timestamp`` came from, and the py_trees
 version.
 
-**The following lines** describe one behaviour each. Before the first tick, every node in the
+**The following lines** describe one behavior each. Before the first tick, every node in the
 tree is written once at ``timestamp`` 0 with status ``INVALID``; afterwards a line is added
-whenever a behaviour's **status** changes. ``feedback_message`` is captured at that moment but
+whenever a behavior's **status** changes. ``feedback_message`` is captured at that moment but
 does not itself trigger a line.
 
 Because the initial snapshot covers the whole tree, the structure and the state at any point
@@ -414,13 +414,13 @@ in time can be reconstructed from the file alone, including branches that never 
    * - ``status``
      - ``INVALID``, ``RUNNING``, ``SUCCESS`` or ``FAILURE``.
    * - ``feedback_message``
-     - The behaviour's feedback message at that moment.
+     - The behavior's feedback message at that moment.
    * - ``is_active``
-     - Whether the behaviour was traversed by the tick that produced this record.
+     - Whether the behavior was traversed by the tick that produced this record.
    * - ``tip_id``
-     - The behaviour that determined this subtree's status (py_trees' ``tip()``), so a failing root points straight at the action responsible. ``null`` on a leaf.
+     - The behavior that determined this subtree's status (py_trees' ``tip()``), so a failing root points straight at the action responsible. ``null`` on a leaf.
    * - ``osc_file``, ``osc_line``, ``osc_column``
-     - Where the behaviour came from in the scenario source. The file is per record because an imported ``.osc`` keeps its own name. Line is 1-based, column 0-based. ``null`` for a behaviour with no source element, e.g. a subtree an action builds internally.
+     - Where the behavior came from in the scenario source. The file is per record because an imported ``.osc`` keeps its own name. Line is 1-based, column 0-based. ``null`` for a behavior with no source element, e.g. a subtree an action builds internally.
    * - ``removed``
      - Present and ``true`` only when a subtree was pruned at runtime; the record then carries just ``timestamp`` and ``behavior_id``.
 
@@ -628,13 +628,13 @@ so existing scenarios continue to work unchanged.
 ``--simulation`` works with both runners:
 
 * ``scenario_execution`` (non-ROS): the simulation drives the loop exclusively
-  (``run_with_simulation``); there is no rclpy, so ROS behaviours are unavailable.
+  (``run_with_simulation``); there is no ``rclpy``, so ROS behaviors are unavailable.
 * ``scenario_execution_ros`` (ROS): the ROS spin loop additionally ticks
   ``simulation.step()``, so a step-based simulation runs **alongside** the ROS
-  behaviours that drive it. This lets a scenario bring up and drive a ROS stack
+  behaviors that drive it. This lets a scenario bring up and drive a ROS stack
   while the simulation advances time. A simulation that publishes ``/clock``
   becomes the time source (other nodes run ``use_sim_time``), and stepping is
-  paced to realtime (the pace can be removed for faster-than-realtime runs).
+  paced to real time (the pace can be removed for faster-than-real-time runs).
 
   With the ROS runner, ``setup()``/``reset()``/``step()``/``shutdown()`` are
   called **per scenario** (each scenario runs on its own ROS node), rather than

--- a/docs/how_to_run.rst
+++ b/docs/how_to_run.rst
@@ -381,7 +381,7 @@ in itself, so reading it is one ``json.loads`` per line with no state to carry a
 
 .. code-block:: json
 
-   {"format":"behaviour_tree_log","version":1,"scenario":"demo","scenario_file":"/scenarios/demo.osc","scenario_sha256":"e175a753…","tick_period":0.1,"clock":"SimulationClock","py_trees":"2.4.0","started_at":"2026-08-06T09:14:22Z"}
+   {"format":"behavior_tree_log","version":1,"scenario":"demo","scenario_file":"/scenarios/demo.osc","scenario_sha256":"e175a753…","tick_period":0.1,"clock":"SimulationClock","py_trees":"2.4.0","started_at":"2026-08-06T09:14:22Z"}
    {"timestamp":0.0,"behavior_id":"0f2b1d8c-…","parent_id":null,"child_index":null,"behavior_name":"demo","class_name":"py_trees.composites.Sequence","type":"SEQUENCE","additional_detail":"","status":"INVALID","feedback_message":"","is_active":false,"tip_id":null,"osc_file":"/scenarios/demo.osc","osc_line":3,"osc_column":0}
    {"timestamp":0.1,"behavior_id":"0f2b1d8c-…","parent_id":null,"child_index":null,"behavior_name":"demo","class_name":"py_trees.composites.Sequence","type":"SEQUENCE","additional_detail":"","status":"RUNNING","feedback_message":"","is_active":true,"tip_id":"e5182a6f-…","osc_file":"/scenarios/demo.osc","osc_line":3,"osc_column":0}
 

--- a/docs/how_to_run.rst
+++ b/docs/how_to_run.rst
@@ -34,8 +34,12 @@ Runtime Parameters
      - (For debugging) Show current state of py tree
    * - ``--post-run POST_RUN_COMMAND``
      - Command or script to run after scenario execution. The command will be called as ``<command> <output_dir>``. Can be specified multiple times; commands are executed in order with a timeout of 10 minutes each. Failures are logged but do not stop subsequent commands. Example: ``--post-run ./post.sh --post-run ./cleanup.sh``
+   * - ``-s STEP_DURATION`` ``--step-duration STEP_DURATION``
+     - Duration in seconds between behavior tree ticks (default: ``0.1``); ticks are paced to it, and a tick that runs longer is reported. With a step-based ``--simulation`` the simulation's ``dt`` governs the tick period instead.
    * - ``--simulation MODULE:CLASS``
      - Step-based simulation interface to use. The value must be in ``module.path:ClassName`` format, where the class implements :class:`SimulationInterface <scenario_execution.SimulationInterface>` and is instantiated with no arguments. See `Step-based simulation`_ for details.
+   * - ``--snapshot-period SECONDS``
+     - Only with ``scenario_execution_ros``. How often to publish the behavior tree state on ``/scenario_execution/snapshots``. By default a snapshot is published only when a behavior's status changes. To record tree progress to a file instead, see `Behavior tree status log`_.
    * - ``--output-result-per-scenario``
      - When more than one scenario is executed (multiple ``scenario`` declarations in the ``.osc`` file, or multiple YAML documents in ``--scenario-parameter-file``), write a separate ``test.xml`` inside each scenario's output subdirectory instead of a single combined ``<output-dir>/test.xml``. Has no effect when only one scenario is executed. See `Per-scenario output directories`_ for details.
 

--- a/docs/libraries.rst
+++ b/docs/libraries.rst
@@ -1577,7 +1577,9 @@ If ``timestamp_suffix`` is set to ``true``, the ROS bag directory ``rosbag2`` wi
 
 If ``topics`` is specified, this action waits for all topics to be subscribed until it returns with success otherwise it immediately returns. The recording is active until the end of the scenario.
 
-A common topic to record is ``/scenario_execution/snapshots`` which publishes changes within the behavior tree. When replaying the bag-file, this allows to visualize the current state of the scenario in RViz, using the ``scenario_execution_rviz`` plugin.
+The ROS runner always publishes ``/scenario_execution/snapshots``, which reports changes within the behavior tree. Recording that topic allows to visualize the state of the scenario in RViz while replaying the bag-file, using the ``scenario_execution_rviz`` plugin.
+
+To capture only what the behavior tree did, use ``--bt-log`` instead (see :ref:`behavior_tree_status_log`). It records status changes rather than republishing the whole tree per snapshot, needs no bag, and works without ROS. The bundled examples therefore no longer record the snapshots topic.
 
 .. list-table:: 
    :widths: 15 15 5 65

--- a/examples/example_multi_robot/scenarios/example_multi_robot.osc
+++ b/examples/example_multi_robot/scenarios/example_multi_robot.osc
@@ -11,7 +11,7 @@ scenario multi_robot:
         robot2.spawn(pose_3d(position_3d(x: -3.0, y: 1.5, z: 0.3), orientation_3d(yaw: -1.57)), model: 'example_multi_robot://models/robot.sdf')
         ros_launch("example_multi_robot", "robot2_launch.py", wait_for_shutdown: false)
         ros_launch("gazebo_static_camera", "spawn_static_camera_launch.py", [ key_value('x', '-3'), key_value('z', '10'), key_value('pitch', '1.57')], wait_for_shutdown: false)
-        bag_record(['/tf', '/tf_static', '/scenario_execution/snapshots', '/map', '/static_camera/image_raw', '/local_costmap/costmap'], use_sim_time: true)
+        bag_record(['/tf', '/tf_static', '/map', '/static_camera/image_raw', '/local_costmap/costmap'], use_sim_time: true)
         parallel:
             test_drive: serial:
                 robot.init_nav2(initial_pose: pose_3d())

--- a/libs/scenario_execution_gazebo/setup.py
+++ b/libs/scenario_execution_gazebo/setup.py
@@ -30,7 +30,7 @@ setup(
     ],
     install_requires=[
         'setuptools',
-        'transforms3d==0.4.1',
+        'transforms3d==0.4.2',  # 0.4.1 calls np.maximum_sctype, removed in NumPy 2.0
         'defusedxml==0.7.1',
     ],
     zip_safe=True,

--- a/libs/scenario_execution_sim/setup.py
+++ b/libs/scenario_execution_sim/setup.py
@@ -30,7 +30,7 @@ setup(
     ],
     install_requires=[
         'setuptools',
-        'transforms3d==0.4.1',
+        'transforms3d==0.4.2',  # 0.4.1 calls np.maximum_sctype, removed in NumPy 2.0
         'defusedxml==0.7.1',
     ],
     zip_safe=True,

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 antlr4-python3-runtime==4.9.2
-transforms3d==0.4.1
+transforms3d==0.4.2
 pexpect==4.8.0
 defusedxml==0.7.1
 pyyaml>=6.0.1

--- a/scenario_execution/scenario_execution/actions/run_process.py
+++ b/scenario_execution/scenario_execution/actions/run_process.py
@@ -23,6 +23,18 @@ from scenario_execution.actions.base_action import BaseAction
 import os
 
 
+def _command_text(command):
+    """A command rendered the way a human reads it, for a log line.
+
+    ``command`` is normally a list of argv tokens, but a subclass may not have set it yet, so this
+    falls back to ``str()`` rather than assuming ``join()`` applies. Matches how ``ros_launch``
+    already reports its command.
+    """
+    if isinstance(command, (list, tuple)):
+        return " ".join(str(part) for part in command)
+    return str(command)
+
+
 class RunProcess(BaseAction):
     """
     Class to execute an process.
@@ -36,6 +48,9 @@ class RunProcess(BaseAction):
         self.shutdown_signal = None
         self.executed = False
         self.process = None
+        #: The command the currently running process was actually started with. Kept separately from
+        #: ``command``, which a re-initialise overwrites before ``update()`` gets to compare them.
+        self.started_command = None
         self.log_stdout_thread = None
         self.log_stderr_thread = None
         self.output = deque()
@@ -64,43 +79,66 @@ class RunProcess(BaseAction):
         """
         if not self.executed:
             self.executed = True
-            try:
-                self.process = subprocess.Popen(
-                    self.command,
-                    start_new_session=True,
-                    stdout=subprocess.PIPE,
-                    stderr=subprocess.PIPE,
-                )
-            except Exception as e:  # pylint: disable=broad-except
-                self.logger.error(str(e))
-                return py_trees.common.Status.FAILURE
-
-            self.feedback_message = f"Executing '{self.command}'"  # pylint: disable= attribute-defined-outside-init
-            self.logger.debug(f"Executing '{self.command}'")
-            self.on_executed()
-
-            def log_output(out, log_fct, buffer):
+            # py_trees re-initialises every child that is not RUNNING, and initialise() calls
+            # execute(), which re-arms this branch. For an action parked in SUCCESS
+            # (wait_for_shutdown: false) that happens on the tick after the root succeeds -- so
+            # spawning again here would rebind self.process to the newborn and lose the handle on the
+            # real child. shutdown() would then signal the newborn's process group and report success
+            # while the real one keeps running, and a simulator that writes its results only on a
+            # clean stop is later killed with nothing written. Keep the process we already own.
+            if self.process is not None and self.process.poll() is None:
+                if self.command != self.started_command:
+                    # Not the benign re-initialise: a *different* process was asked for while the
+                    # previous one runs. Say so; silently running the old one hides the divergence.
+                    self.logger.warning(
+                        f"Re-initialised with a different command while still running "
+                        f"'{_command_text(self.started_command)}'; keeping it and ignoring "
+                        f"'{_command_text(self.command)}'.")
+                else:
+                    self.logger.debug('Re-initialised while still running; keeping the process.')
+                # Deliberately no early return: the checks below are the one place that turns a
+                # process state into a status, and on_executed()/the reader threads must not run
+                # again for a process that is already going (the on_executed() overrides reset
+                # current_state to a *waiting* state, which this process is long past).
+            else:
                 try:
-                    for line in iter(out.readline, b''):
-                        msg = line.decode().strip()
-                        if log_fct:
-                            log_fct(msg)
-                        with self.output_lock:
-                            buffer.append(msg)
-                    out.close()
-                except ValueError:
-                    pass
+                    self.process = subprocess.Popen(
+                        self.command,
+                        start_new_session=True,
+                        stdout=subprocess.PIPE,
+                        stderr=subprocess.PIPE,
+                    )
                 except Exception as e:  # pylint: disable=broad-except
-                    self.logger.error(f"Error while logging output: {e}")
-            self.log_stdout_thread = Thread(target=log_output, args=(
-                self.process.stdout, self.get_logger_stdout(), self.output))
-            self.log_stdout_thread.daemon = True  # die with the program
-            self.log_stdout_thread.start()
+                    self.logger.error(str(e))
+                    return py_trees.common.Status.FAILURE
+                self.started_command = self.command
 
-            self.log_stderr_thread = Thread(target=log_output, args=(
-                self.process.stderr, self.get_logger_stderr(), self.output))
-            self.log_stderr_thread.daemon = True  # die with the program
-            self.log_stderr_thread.start()
+                self.feedback_message = f"Executing '{self.command}'"  # pylint: disable= attribute-defined-outside-init
+                self.logger.debug(f"Executing '{self.command}'")
+                self.on_executed()
+
+                def log_output(out, log_fct, buffer):
+                    try:
+                        for line in iter(out.readline, b''):
+                            msg = line.decode().strip()
+                            if log_fct:
+                                log_fct(msg)
+                            with self.output_lock:
+                                buffer.append(msg)
+                        out.close()
+                    except ValueError:
+                        pass
+                    except Exception as e:  # pylint: disable=broad-except
+                        self.logger.error(f"Error while logging output: {e}")
+                self.log_stdout_thread = Thread(target=log_output, args=(
+                    self.process.stdout, self.get_logger_stdout(), self.output))
+                self.log_stdout_thread.daemon = True  # die with the program
+                self.log_stdout_thread.start()
+
+                self.log_stderr_thread = Thread(target=log_output, args=(
+                    self.process.stderr, self.get_logger_stderr(), self.output))
+                self.log_stderr_thread.daemon = True  # die with the program
+                self.log_stderr_thread.start()
 
         if self.process is None:
             self.process = None

--- a/scenario_execution/scenario_execution/model/model_to_py_tree.py
+++ b/scenario_execution/scenario_execution/model/model_to_py_tree.py
@@ -143,10 +143,28 @@ class ModelToPyTree(object):
             self.tree = tree
             self.__cur_behavior = tree
 
+        @staticmethod
+        def stamp_source(behavior, node):
+            """Record which .osc element a behaviour came from, as (file, line, column).
+
+            Only plugin actions can be traced back today, and only indirectly, via the
+            model they keep in BaseAction._model. Composites, decorators and the built-in
+            behaviours below are plain py_trees objects with no model reference at all, so
+            anything reading a tree at runtime -- a status log, a debugger -- cannot say
+            which line of the scenario a node came from. Stamping every behaviour here
+            keeps that uniform. Line is 1-based, column 0-based, straight from ANTLR.
+
+            The file comes from the model element rather than the entry scenario because
+            an imported .osc carries its own name (model_builder passes current_file).
+            """
+            line, column, _, filename = node.get_ctx()
+            behavior.osc_source = (filename, line, column)
+
         def visit_scenario_declaration(self, node: ScenarioDeclaration):
             scenario_name = node.qualified_behavior_name
 
             self.__cur_behavior.name = scenario_name
+            self.stamp_source(self.__cur_behavior, node)
 
             self.blackboard = self.__cur_behavior.attach_blackboard_client(
                 name="ModelToPyTree")
@@ -167,6 +185,7 @@ class ModelToPyTree(object):
             else:
                 raise NotImplementedError(f"scenario operator {composition_operator} not yet supported.")
 
+            self.stamp_source(behavior, node)
             parent = self.__cur_behavior
             self.__cur_behavior.add_child(behavior)
             self.__cur_behavior = behavior
@@ -179,6 +198,7 @@ class ModelToPyTree(object):
             if isinstance(child, (EventCondition, EventReference)):
                 behavior = self.visit(child)
 
+                self.stamp_source(behavior, node)
                 self.__cur_behavior.add_child(behavior)
             else:
                 raise OSC2ParsingError(msg="Invalid wait directive.", context=node.get_ctx())
@@ -188,12 +208,14 @@ class ModelToPyTree(object):
                 scenario_elem = node
                 while scenario_elem is not None and not isinstance(scenario_elem, ScenarioDeclaration):
                     scenario_elem = scenario_elem.get_parent()
-                self.__cur_behavior.add_child(TopicPublish(
-                    name=f"emit {node.event_name}", key=f"/{scenario_elem.name}/{node.event_name}", msg=True))
+                behavior = TopicPublish(
+                    name=f"emit {node.event_name}", key=f"/{scenario_elem.name}/{node.event_name}", msg=True)
             else:
                 qualified_name = node.event.get_qualified_name()
-                self.__cur_behavior.add_child(TopicPublish(
-                    name=f"emit {node.event_name}", key=qualified_name, msg=True))
+                behavior = TopicPublish(
+                    name=f"emit {node.event_name}", key=qualified_name, msg=True)
+            self.stamp_source(behavior, node)
+            self.__cur_behavior.add_child(behavior)
 
         def compare_method_arguments(self, method, expected_args, behavior_name, node):
             method_args = inspect.getfullargspec(method).args
@@ -211,7 +233,11 @@ class ModelToPyTree(object):
                     missing_args.remove(element)
             return method_args, unexpected_args, missing_args
 
-        def create_decorator(self, node: ModifierDeclaration, resolved_values):
+        def create_decorator(self, node: ModifierDeclaration, resolved_values, invocation=None):
+            # *node* is the modifier's declaration, which for a built-in modifier lives in
+            # an imported library -- useless as a source anchor. *invocation* is the call
+            # site in the scenario, which is what a reader wants to be pointed at.
+            source_node = invocation if invocation is not None else node
             available_modifiers = ["repeat", "inverter", "timeout", "retry", "failure_is_running", "failure_is_success",
                                    "running_is_failure", "running_is_success", "success_is_failure", "success_is_running"]
             if node.name not in available_modifiers:
@@ -221,6 +247,7 @@ class ModelToPyTree(object):
                     if ep.name == node.name:
                         factory = ep.load()
                         instance = factory(self.__cur_behavior, resolved_values)
+                        self.stamp_source(instance, source_node)
                         parent = self.__cur_behavior.parent
                         if parent:
                             parent.children.remove(self.__cur_behavior)
@@ -265,6 +292,7 @@ class ModelToPyTree(object):
             else:
                 raise ValueError('unknown modifier (should not reach here).')
 
+            self.stamp_source(instance, source_node)
             if isinstance(parent, py_trees.composites.Composite):
                 parent.add_child(instance)
             elif isinstance(parent, py_trees.decorators.Decorator):
@@ -282,7 +310,7 @@ class ModelToPyTree(object):
             if isinstance(node.behavior, ModifierDeclaration):
                 resolved_values = node.get_resolved_value(self.blackboard)
                 try:
-                    self.create_decorator(node.behavior, resolved_values)
+                    self.create_decorator(node.behavior, resolved_values, invocation=node)
                 except ValueError as e:
                     raise OSC2ParsingError(msg=f'Modifier "{node.behavior.name}" {e}.', context=node.get_ctx()) from e
             elif isinstance(node.behavior, ActionDeclaration):
@@ -385,6 +413,7 @@ class ModelToPyTree(object):
                     instance._external_init_args = remote_init_args  # pylint: disable=protected-access
                 except Exception as e:
                     raise OSC2ParsingError(msg=f'Error while initializing plugin {behavior_name}: {e}', context=node.get_ctx()) from e
+                self.stamp_source(instance, node)
                 self.__cur_behavior.add_child(instance)
                 previous = self.__cur_behavior
                 self.__cur_behavior = instance
@@ -448,7 +477,7 @@ class ModelToPyTree(object):
         def visit_modifier_invocation(self, node: ModifierInvocation):
             resolved_values = node.get_resolved_value()
             try:
-                self.create_decorator(node.modifier, resolved_values)
+                self.create_decorator(node.modifier, resolved_values, invocation=node)
             except ValueError as e:
                 raise OSC2ParsingError(msg=f'ModifierDeclaration {e}.', context=node.get_ctx()) from e
 

--- a/scenario_execution/scenario_execution/scenario_execution_base.py
+++ b/scenario_execution/scenario_execution/scenario_execution_base.py
@@ -26,6 +26,7 @@ from datetime import datetime, timedelta
 import py_trees
 from scenario_execution.model.osc2_parser import OpenScenario2Parser
 from scenario_execution.utils.logging import Logger
+from scenario_execution.utils import bt_logger
 from scenario_execution.model.model_file_loader import ModelFileLoader
 from scenario_execution.simulation import SimulationClock
 from scenario_execution.actions.process_registry import ProcessRegistry
@@ -156,7 +157,8 @@ class ScenarioExecution(object):
                  logger=None,
                  register_signal=True,
                  simulation=None,
-                 output_result_per_scenario: bool = False) -> None:
+                 output_result_per_scenario: bool = False,
+                 bt_log: bool = False) -> None:
 
         def signal_handler(sig, frame):
             self.on_scenario_shutdown(False, "Aborted")
@@ -210,6 +212,8 @@ class ScenarioExecution(object):
         self.blackboard = None
         self.behaviour_tree = None
         self.last_snapshot_visitor = None
+        self.bt_log = bt_log
+        self.bt_logger = None
         self.shutdown_requested = False
         self.results = []
         self.create_scenario_parameter_file_template = create_scenario_parameter_file_template
@@ -249,6 +253,7 @@ class ScenarioExecution(object):
         self.blackboard.fail = False
         self.behaviour_tree = self.setup_behaviour_tree(scenario)  # Get the behaviour_tree
         self.behaviour_tree.add_pre_tick_handler(self.pre_tick_handler)
+        self._setup_bt_logger(effective_output_dir, kwargs)
         self.behaviour_tree.add_post_tick_handler(self.post_tick_handler)
         self.last_snapshot_visitor = LastSnapshotVisitor()
         self.behaviour_tree.add_visitor(self.last_snapshot_visitor)
@@ -271,6 +276,38 @@ class ScenarioExecution(object):
                                   tick_period=self.tick_period,
                                   **setup_kwargs)
         self.post_setup()
+
+    def _setup_bt_logger(self, output_dir, setup_kwargs):
+        """Attach the behaviour-tree status log for this scenario, if --bt-log is set.
+
+        Middleware-independent: the ROS runner inherits this untouched and contributes
+        only the clock. ``sim_clock`` is preferred over ``clock`` so a runner can supply
+        a time source for the log alone -- passing ``clock`` would also retarget
+        ClockTimer/ClockTimeout, changing when timeouts fire.
+        """
+        self.close_bt_logger()
+        if not self.bt_log:
+            return
+        if not output_dir:
+            raise ValueError("--bt-log requires --output-dir.")
+        clock = setup_kwargs.get('sim_clock') or setup_kwargs.get('clock')
+        path = os.path.join(output_dir, bt_logger.DEFAULT_FILENAME)
+        meta = bt_logger.build_meta(
+            scenario_name=self.current_scenario.name,
+            scenario_file=self.scenario_file,
+            tick_period=self.tick_period,
+            clock=clock)
+        self.bt_logger = bt_logger.BehaviourTreeJsonlLogger(path, meta, clock)
+        self.behaviour_tree.add_visitor(self.bt_logger.snapshot_visitor)
+        # Before the first tick, so nodes that never run are still in the file.
+        self.bt_logger.write_initial_snapshot(self.behaviour_tree)
+        self.behaviour_tree.add_post_tick_handler(self.bt_logger)
+        self.logger.info(f"Recording behaviour tree status to {path}")
+
+    def close_bt_logger(self):
+        if self.bt_logger is not None:
+            self.bt_logger.close()
+            self.bt_logger = None
 
     def setup_behaviour_tree(self, tree):
         """
@@ -451,6 +488,7 @@ class ScenarioExecution(object):
                     self.on_scenario_shutdown(False, "Aborted")
                     return
         finally:
+            self.close_bt_logger()
             try:
                 simulation.shutdown()
             except Exception as e:  # pylint: disable=broad-except
@@ -608,6 +646,7 @@ class ScenarioExecution(object):
         self.shutdown_requested = True
         if self.behaviour_tree:
             self.behaviour_tree.interrupt()
+        self.close_bt_logger()
         if self.current_scenario:
             if result:
                 self.logger.info(f"Scenario '{self.current_scenario.name}' succeeded.")
@@ -642,6 +681,8 @@ class ScenarioExecution(object):
                             help='Produce tree output of parsed openscenario2 content')
         parser.add_argument('-t', '--live-tree', action='store_true',
                             help='For debugging: Show current state of py tree')
+        parser.add_argument('--bt-log', action='store_true',
+                            help=f'Record behaviour status over time to <output-dir>/{bt_logger.DEFAULT_FILENAME}')
         parser.add_argument('-o', '--output-dir', type=str, help='Directory for output (e.g. test results)')
         parser.add_argument('-n', '--dry-run', action='store_true', help='Parse and resolve scenario, but do not execute')
         parser.add_argument('--dot', action='store_true', help='Render dot trees of resulting py-tree')
@@ -751,7 +792,8 @@ def main():
                                                create_scenario_parameter_file_template=args.create_scenario_parameter_file_template,
                                                post_run=args.post_run,
                                                simulation=simulation,
-                                               output_result_per_scenario=args.output_result_per_scenario)
+                                               output_result_per_scenario=args.output_result_per_scenario,
+                                               bt_log=args.bt_log)
     except ValueError as e:
         print(f"Error while initializing: {e}")
         sys.exit(1)

--- a/scenario_execution/scenario_execution/utils/bt_logger.py
+++ b/scenario_execution/scenario_execution/utils/bt_logger.py
@@ -1,0 +1,256 @@
+# Copyright (C) 2026 Frederik Pasch
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions
+# and limitations under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""Record behaviour-tree status over time to a self-contained JSONL file.
+
+Middleware-independent: this module imports nothing but the standard library and
+py_trees, so the same writer serves the plain and the ROS runner. The only thing
+the ROS runner contributes is a :class:`~scenario_execution.simulation.Clock`
+implementation reading ``/clock``.
+
+File layout -- one JSON object per line:
+
+* line 1 is the metadata record, identified by its ``format`` key: which scenario
+  file was run (and its sha256), the tick period, which clock ``timestamp`` comes
+  from, and the py_trees version.
+* line 2..n+1 are a snapshot of every node in the tree at ``timestamp`` 0, all
+  ``INVALID``. Without it, branches that never tick would be missing from the file
+  entirely and the tree could not be fully reconstructed.
+* afterwards, one record per behaviour whose **status** changed. ``feedback_message``
+  is captured as it stands at that moment but does not itself trigger a record --
+  some actions rewrite it every tick, which would turn this into a per-tick dump.
+
+Records carry the full node description rather than referring back to the snapshot,
+so every line stands on its own and reading the file is ``json.loads`` per line.
+The field set follows ``py_trees_ros_interfaces/Behaviour`` -- see
+:func:`_behaviour_record` for what is taken and what is deliberately left out.
+"""
+
+import hashlib
+import json
+import os
+import time
+from datetime import datetime, timezone
+
+import py_trees
+
+FORMAT_NAME = "behaviour_tree_log"
+FORMAT_VERSION = 1
+
+DEFAULT_FILENAME = "behaviors.jsonl"
+
+
+def _behaviour_type(behaviour) -> str:
+    """Node kind, mirroring py_trees_ros' ``behaviour_type_to_msg_constant``."""
+    if isinstance(behaviour, py_trees.composites.Sequence):
+        return "SEQUENCE"
+    if isinstance(behaviour, py_trees.composites.Selector):
+        return "SELECTOR"
+    if isinstance(behaviour, py_trees.composites.Parallel):
+        return "PARALLEL"
+    if isinstance(behaviour, py_trees.decorators.Decorator):
+        return "DECORATOR"
+    if isinstance(behaviour, py_trees.behaviour.Behaviour):
+        return "BEHAVIOUR"
+    return "UNKNOWN_TYPE"
+
+
+def _additional_detail(behaviour) -> str:
+    """Policy information, mirroring py_trees_ros' ``additional_detail_to_str``."""
+    if isinstance(behaviour, py_trees.composites.Parallel):
+        try:
+            policy = behaviour.policy.__class__.__name__.replace("Success", "")
+        except AttributeError:
+            return ""
+        try:
+            indices = [str(behaviour.children.index(child)) for child in behaviour.policy.children]
+            policy += "({})".format(", ".join(sorted(indices)))
+        except AttributeError:
+            pass
+        return policy
+    return ""
+
+
+def _child_index(behaviour):
+    """Position among the parent's children -- ``parent_id`` alone yields an unordered set."""
+    parent = behaviour.parent
+    if parent is None:
+        return None
+    try:
+        return parent.children.index(behaviour)
+    except ValueError:
+        return None
+
+
+def _tip_id(behaviour):
+    """The leaf that determined this subtree's status, or None for a leaf/invalid node.
+
+    py_trees' ``tip()`` recurses through ``current_child`` (composites) and
+    ``decorated`` (decorators), so on an ancestor this names the behaviour actually
+    responsible for its status -- the one field here that cannot be recomputed from
+    the others, since ``current_child`` is not logged.
+    """
+    tip = behaviour.tip()
+    if tip is None or tip is behaviour:
+        return None
+    return str(tip.id)
+
+
+def _behaviour_record(behaviour, timestamp: float, is_active: bool) -> dict:
+    """One complete description of *behaviour* at *timestamp*.
+
+    Fields follow ``py_trees_ros_interfaces/Behaviour``. Left out on purpose:
+    ``child_ids`` and ``current_child_id`` (``child_index`` orders children and
+    ``tip_id`` carries what ``current_child_id`` was needed for), ``blackbox_level``
+    and ``blackboard_access`` (the blackboard is a separate concern).
+    """
+    source = getattr(behaviour, "osc_source", None)
+    osc_file, osc_line, osc_column = source if source else (None, None, None)
+    return {
+        "timestamp": timestamp,
+        "behavior_id": str(behaviour.id),
+        "parent_id": str(behaviour.parent.id) if behaviour.parent else None,
+        "child_index": _child_index(behaviour),
+        "behavior_name": behaviour.name,
+        "class_name": py_trees.utilities.get_fully_qualified_name(behaviour),
+        "type": _behaviour_type(behaviour),
+        "additional_detail": _additional_detail(behaviour),
+        "status": behaviour.status.name,
+        "feedback_message": behaviour.feedback_message,
+        "is_active": is_active,
+        "tip_id": _tip_id(behaviour),
+        "osc_file": osc_file,
+        "osc_line": osc_line,
+        "osc_column": osc_column,
+    }
+
+
+def file_sha256(path: str):
+    """Hash of *path*, or None if it cannot be read (a scenario given inline has no file)."""
+    if not path or not os.path.isfile(path):
+        return None
+    digest = hashlib.sha256()
+    with open(path, "rb") as handle:
+        for chunk in iter(lambda: handle.read(65536), b""):
+            digest.update(chunk)
+    return digest.hexdigest()
+
+
+def build_meta(scenario_name: str, scenario_file: str, tick_period: float, clock) -> dict:
+    """The file's first line: what produced it and what ``timestamp`` means."""
+    return {
+        "format": FORMAT_NAME,
+        "version": FORMAT_VERSION,
+        "scenario": scenario_name,
+        "scenario_file": scenario_file,
+        "scenario_sha256": file_sha256(scenario_file),
+        "tick_period": tick_period,
+        "clock": type(clock).__name__ if clock is not None else "monotonic",
+        "py_trees": py_trees.version.__version__,
+        "started_at": datetime.now(timezone.utc).isoformat(timespec="seconds"),
+    }
+
+
+class BehaviourTreeJsonlLogger(object):
+    """Post-tick handler writing behaviour status changes to a JSONL file.
+
+    Usage::
+
+        logger = BehaviourTreeJsonlLogger(path, meta, clock)
+        behaviour_tree.add_visitor(logger.snapshot_visitor)
+        logger.write_initial_snapshot(behaviour_tree)   # before the first tick
+        behaviour_tree.add_post_tick_handler(logger)
+        ...
+        logger.close()
+
+    Args:
+        path: file to write; the parent directory must exist.
+        meta: the metadata record, see :func:`build_meta`.
+        clock: time source for ``timestamp``. ``None`` falls back to monotonic time
+            measured from the initial snapshot, so ``timestamp`` counts from zero
+            either way.
+    """
+
+    def __init__(self, path: str, meta: dict, clock=None):
+        self._clock = clock
+        self._monotonic_start = None
+        # id -> last status written, the only state needed to emit deltas
+        self._last_status = {}
+        # Which behaviours the tick actually traversed. py_trees_ros fills its
+        # `is_active` from the same source; a node can hold SUCCESS from an earlier
+        # tick without being on the current path, so status alone cannot say this.
+        self.snapshot_visitor = py_trees.visitors.SnapshotVisitor()
+        self._file = open(path, "w", encoding="utf-8")  # pylint: disable=consider-using-with
+        self._write(meta)
+
+    @property
+    def closed(self) -> bool:
+        return self._file is None
+
+    def now(self) -> float:
+        """Seconds since the scenario started -- simulated time when a clock is given."""
+        if self._clock is not None:
+            return self._clock.now()
+        if self._monotonic_start is None:
+            self._monotonic_start = time.monotonic()
+        return time.monotonic() - self._monotonic_start
+
+    def write_initial_snapshot(self, behaviour_tree) -> None:
+        """Record every node at ``timestamp`` 0, before the tree has ticked.
+
+        Called separately from the post-tick handler because by the first post-tick
+        the statuses have already changed -- and a node that never ticks would
+        otherwise never appear.
+        """
+        if self._monotonic_start is None:
+            self._monotonic_start = time.monotonic()
+        for behaviour in behaviour_tree.root.iterate():
+            self._write(_behaviour_record(behaviour, 0.0, is_active=False))
+            self._last_status[behaviour.id] = behaviour.status
+
+    def __call__(self, behaviour_tree) -> None:
+        """Post-tick handler: a record per behaviour whose status changed."""
+        if self._file is None:
+            return
+        timestamp = self.now()
+        visited = self.snapshot_visitor.visited
+        present = set()
+        for behaviour in behaviour_tree.root.iterate():
+            present.add(behaviour.id)
+            # A node absent from _last_status was inserted at runtime (insert_subtree,
+            # BaseActionSubtree); it gets a full record on first sight, same as any
+            # status change would produce.
+            if self._last_status.get(behaviour.id, None) == behaviour.status:
+                continue
+            self._last_status[behaviour.id] = behaviour.status
+            self._write(_behaviour_record(behaviour, timestamp, is_active=behaviour.id in visited))
+        for gone in [i for i in self._last_status if i not in present]:
+            # Unlike py_trees_ros there is no whole-tree resend to imply the absence
+            # of a pruned subtree, so it is stated.
+            del self._last_status[gone]
+            self._write({"timestamp": timestamp, "behavior_id": str(gone), "removed": True})
+
+    def _write(self, record: dict) -> None:
+        json.dump(record, self._file, separators=(",", ":"))
+        self._file.write("\n")
+        # Flushed per record so a killed or timed-out run keeps what it wrote -- which
+        # is exactly the run whose tree state is worth reading.
+        self._file.flush()
+
+    def close(self) -> None:
+        if self._file is not None:
+            self._file.close()
+            self._file = None

--- a/scenario_execution/scenario_execution/utils/bt_logger.py
+++ b/scenario_execution/scenario_execution/utils/bt_logger.py
@@ -47,7 +47,7 @@ from datetime import datetime, timezone
 
 import py_trees
 
-FORMAT_NAME = "behaviour_tree_log"
+FORMAT_NAME = "behavior_tree_log"
 FORMAT_VERSION = 1
 
 DEFAULT_FILENAME = "behaviors.jsonl"

--- a/scenario_execution/scenario_execution/utils/logging.py
+++ b/scenario_execution/scenario_execution/utils/logging.py
@@ -14,6 +14,12 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
+import time
+
+YELLOW = '\033[33m'
+RED = '\033[31m'
+RESET = '\033[0m'
+
 
 class BaseLogger(object):
     """
@@ -69,41 +75,61 @@ class BaseLogger(object):
 class Logger(BaseLogger):
     """
     Class for logger for scenario execution
+
+    Lines are printed as ``[LEVEL] [epoch] [name]: msg``, which is the format the ROS
+    logger (``scenario_execution_ros.logging_ros.RosLogger``, via rclpy) already produces.
+    The two implementations of this one base class used to disagree -- this one printed
+    ``[name] [INFO] msg`` with no timestamp at all -- so whether a scenario's own output
+    could be placed in time depended on which middleware happened to be in use. Tooling
+    that reads a run's log has one grammar to parse either way now.
+
+    The timestamp is wall-clock epoch seconds, matching rclpy. It is not sim time: a log
+    line is an event in the process that printed it, and correlating that with a simulator's
+    clock is the reader's job, which cannot be done at all without a wall stamp here.
+
+    The ANSI colour wraps the *message* rather than the whole line, so that the level marker
+    stays at the start where a parser (and a human scanning a column) finds it. Leading
+    escape bytes would hide the marker behind an anchored match while still looking correct
+    on a terminal, which is the kind of breakage nothing reports.
     """
+
+    def _emit(self, level: str, msg: str, colour: str = '') -> None:
+        stamp = f'[{level}] [{time.time():.6f}] [{self.name}]: '
+        print(f'{stamp}{colour}{msg}{RESET if colour else ""}')
 
     def info(self, msg: str) -> None:
         """
-        Print a info with logger name and "[INFO]" in the front.
+        Print an info line.
 
         Args:
             msg [str]: msg to print
         """
-        print(f'[{self.name}] [INFO] {msg}')
+        self._emit('INFO', msg)
 
     def debug(self, msg: str) -> None:
         """
-        Print debug info with logger name and "[DEBUG]" in the front.
+        Print a debug line, when debug logging is enabled.
 
         Args:
             msg [str]: msg to print
         """
         if self.log_debug:
-            print(f'[{self.name}] [DEBUG] {msg}')
+            self._emit('DEBUG', msg)
 
     def warning(self, msg: str) -> None:
         """
-        Print a warning in yellow color with logger name and "[WARN]" in the front.
+        Print a warning, with the message in yellow.
 
         Args:
             msg [str]: msg to print
         """
-        print(f'\033[33m[{self.name}] [WARN] {msg}\033[0m')
+        self._emit('WARN', msg, YELLOW)
 
     def error(self, msg: str) -> None:
         """
-        Print a warning in red color with logger name and "[ERROR]" in the front.
+        Print an error, with the message in red.
 
         Args:
             msg [str]: msg to print
         """
-        print(f'\033[31m[{self.name}] [ERROR] {msg}\033[0m')
+        self._emit('ERROR', msg, RED)

--- a/scenario_execution/test/test_bt_logger.py
+++ b/scenario_execution/test/test_bt_logger.py
@@ -91,7 +91,7 @@ class TestBtLogger(unittest.TestCase):
         tree = self.simple_tree()
         self.build_logger(tree, self.clock).close()
         meta, _ = self.read()
-        self.assertEqual(meta["format"], "behaviour_tree_log")
+        self.assertEqual(meta["format"], "behavior_tree_log")
         self.assertEqual(meta["scenario"], "test")
         self.assertEqual(meta["clock"], "FakeClock")
         self.assertIsNotNone(meta["py_trees"])
@@ -263,7 +263,7 @@ class TestBtLogger(unittest.TestCase):
         self.build_logger(tree, self.clock)
         tree.tick()
         meta, events = self.read()  # no close()
-        self.assertEqual(meta["format"], "behaviour_tree_log")
+        self.assertEqual(meta["format"], "behavior_tree_log")
         self.assertTrue(events)
 
 

--- a/scenario_execution/test/test_bt_logger.py
+++ b/scenario_execution/test/test_bt_logger.py
@@ -1,0 +1,271 @@
+# Copyright (C) 2026 Frederik Pasch
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions
+# and limitations under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""
+Test the behaviour tree status log (--bt-log)
+"""
+import json
+import os
+import tempfile
+import unittest
+
+import py_trees
+
+from scenario_execution.simulation import Clock
+from scenario_execution.utils.bt_logger import BehaviourTreeJsonlLogger, build_meta
+
+
+class FakeClock(Clock):
+    """A clock the test advances by hand, standing in for a SimulationClock."""
+
+    def __init__(self):
+        self.value = 0.0
+
+    def now(self) -> float:
+        return self.value
+
+
+class Countdown(py_trees.behaviour.Behaviour):
+    """RUNNING for *ticks* ticks, then SUCCESS."""
+
+    def __init__(self, name, ticks):
+        super().__init__(name)
+        self.remaining = ticks
+
+    def update(self):
+        self.remaining -= 1
+        self.feedback_message = f"{self.remaining} left"
+        if self.remaining <= 0:
+            return py_trees.common.Status.SUCCESS
+        return py_trees.common.Status.RUNNING
+
+
+class TestBtLogger(unittest.TestCase):
+    # pylint: disable=missing-function-docstring
+
+    def setUp(self):
+        self.tmp = tempfile.TemporaryDirectory()  # pylint: disable=consider-using-with
+        self.path = os.path.join(self.tmp.name, "behaviors.jsonl")
+        self.clock = FakeClock()
+
+    def tearDown(self):
+        self.tmp.cleanup()
+
+    def build_logger(self, tree, clock=None):
+        logger = BehaviourTreeJsonlLogger(
+            self.path, build_meta("test", "test.osc", 0.1, clock), clock)
+        tree.add_visitor(logger.snapshot_visitor)
+        logger.write_initial_snapshot(tree)
+        tree.add_post_tick_handler(logger)
+        return logger
+
+    def read(self):
+        with open(self.path, encoding="utf-8") as handle:
+            records = [json.loads(line) for line in handle]
+        return records[0], records[1:]
+
+    @staticmethod
+    def simple_tree():
+        """root(Sequence) -> [slow(2 ticks), inner(Sequence) -> [quick, never]]"""
+        root = py_trees.composites.Sequence(name="root", memory=True)
+        inner = py_trees.composites.Sequence(name="inner", memory=True)
+        inner.add_children([py_trees.behaviours.Success(name="quick"),
+                            py_trees.behaviours.Success(name="never")])
+        root.add_children([Countdown("slow", 2), inner])
+        return py_trees.trees.BehaviourTree(root)
+
+    def test_meta_record(self):
+        tree = self.simple_tree()
+        self.build_logger(tree, self.clock).close()
+        meta, _ = self.read()
+        self.assertEqual(meta["format"], "behaviour_tree_log")
+        self.assertEqual(meta["scenario"], "test")
+        self.assertEqual(meta["clock"], "FakeClock")
+        self.assertIsNotNone(meta["py_trees"])
+
+    def test_initial_snapshot_covers_every_node(self):
+        tree = self.simple_tree()
+        logger = self.build_logger(tree, self.clock)
+        logger.close()
+        _, events = self.read()
+        self.assertTrue(all(e["timestamp"] == 0.0 for e in events))
+        self.assertTrue(all(e["status"] == "INVALID" for e in events))
+        self.assertEqual({e["behavior_name"] for e in events},
+                         {"root", "slow", "inner", "quick", "never"})
+
+    def test_never_ticked_node_is_recorded(self):
+        # 'never' is only reached after 'quick', which only runs once 'slow' succeeds.
+        # A pure delta stream would omit a branch like this entirely.
+        tree = self.simple_tree()
+        logger = self.build_logger(tree, self.clock)
+        tree.tick()
+        logger.close()
+        _, events = self.read()
+        self.assertIn("never", {e["behavior_name"] for e in events})
+
+    def test_record_per_status_change_only(self):
+        tree = self.simple_tree()
+        logger = self.build_logger(tree, self.clock)
+        _, initial = self.read()
+        for _ in range(3):
+            self.clock.value += 0.5
+            tree.tick()
+        logger.close()
+        _, events = self.read()
+        changes = events[len(initial):]
+        self.assertTrue(changes)
+        for behavior_id in {e["behavior_id"] for e in changes}:
+            statuses = [e["status"] for e in changes if e["behavior_id"] == behavior_id]
+            self.assertEqual(statuses, list(dict.fromkeys(statuses)),
+                             "a status was recorded twice in a row")
+
+    def test_timestamp_from_clock(self):
+        tree = self.simple_tree()
+        logger = self.build_logger(tree, self.clock)
+        self.clock.value = 12.5
+        tree.tick()
+        logger.close()
+        _, events = self.read()
+        self.assertEqual({e["timestamp"] for e in events if e["timestamp"] != 0.0}, {12.5})
+
+    def test_timestamp_without_clock_starts_at_zero(self):
+        tree = self.simple_tree()
+        logger = self.build_logger(tree, clock=None)
+        tree.tick()
+        logger.close()
+        meta, events = self.read()
+        self.assertEqual(meta["clock"], "monotonic")
+        self.assertTrue(all(0.0 <= e["timestamp"] < 5.0 for e in events))
+
+    def test_child_index_orders_siblings(self):
+        tree = self.simple_tree()
+        self.build_logger(tree, self.clock).close()
+        _, events = self.read()
+        by_name = {e["behavior_name"]: e for e in events}
+        self.assertIsNone(by_name["root"]["parent_id"])
+        self.assertIsNone(by_name["root"]["child_index"])
+        self.assertEqual(by_name["slow"]["child_index"], 0)
+        self.assertEqual(by_name["inner"]["child_index"], 1)
+        self.assertEqual(by_name["quick"]["child_index"], 0)
+        self.assertEqual(by_name["never"]["child_index"], 1)
+
+    def test_tree_is_reconstructable(self):
+        tree = self.simple_tree()
+        logger = self.build_logger(tree, self.clock)
+        for _ in range(3):
+            self.clock.value += 0.5
+            tree.tick()
+        logger.close()
+        _, events = self.read()
+
+        nodes = {}
+        for event in events:
+            nodes.setdefault(event["behavior_id"], event).update(event)
+        children = {}
+        for node in nodes.values():
+            if node["parent_id"] is not None:
+                self.assertIn(node["parent_id"], nodes, "dangling parent_id")
+                children.setdefault(node["parent_id"], []).append(node)
+        for siblings in children.values():
+            siblings.sort(key=lambda n: n["child_index"])
+
+        def names(node):
+            return [n["behavior_name"] for n in children.get(node["behavior_id"], [])]
+
+        root = next(n for n in nodes.values() if n["parent_id"] is None)
+        self.assertEqual(root["behavior_name"], "root")
+        self.assertEqual(names(root), ["slow", "inner"])
+        inner = next(n for n in nodes.values() if n["behavior_name"] == "inner")
+        self.assertEqual(names(inner), ["quick", "never"])
+
+    def test_types_and_tip(self):
+        tree = self.simple_tree()
+        logger = self.build_logger(tree, self.clock)
+        self.clock.value = 1.0
+        tree.tick()
+        logger.close()
+        _, events = self.read()
+        running = [e for e in events if e["timestamp"] == 1.0]
+        root = next(e for e in running if e["behavior_name"] == "root")
+        slow = next(e for e in running if e["behavior_name"] == "slow")
+        self.assertEqual(root["type"], "SEQUENCE")
+        self.assertEqual(slow["type"], "BEHAVIOUR")
+        # The ancestor points at the leaf that determined its status; the leaf itself
+        # has no tip, matching py_trees_ros.
+        self.assertEqual(root["tip_id"], slow["behavior_id"])
+        self.assertIsNone(slow["tip_id"])
+        self.assertTrue(slow["is_active"])
+        self.assertEqual(slow["feedback_message"], "1 left")
+
+    def test_parallel_policy_in_additional_detail(self):
+        root = py_trees.composites.Parallel(
+            name="par", policy=py_trees.common.ParallelPolicy.SuccessOnAll())
+        root.add_child(py_trees.behaviours.Running(name="forever"))
+        tree = py_trees.trees.BehaviourTree(root)
+        self.build_logger(tree, self.clock).close()
+        _, events = self.read()
+        par = next(e for e in events if e["behavior_name"] == "par")
+        self.assertEqual(par["type"], "PARALLEL")
+        self.assertIn("OnAll", par["additional_detail"])
+
+    def test_osc_source_is_reported_when_stamped(self):
+        tree = self.simple_tree()
+        tree.root.osc_source = ("/scenarios/demo.osc", 12, 4)
+        self.build_logger(tree, self.clock).close()
+        _, events = self.read()
+        root = next(e for e in events if e["behavior_name"] == "root")
+        unstamped = next(e for e in events if e["behavior_name"] == "quick")
+        self.assertEqual(
+            (root["osc_file"], root["osc_line"], root["osc_column"]),
+            ("/scenarios/demo.osc", 12, 4))
+        # A behaviour with no source element is a legitimate absence, not an error.
+        self.assertIsNone(unstamped["osc_file"])
+
+    def test_runtime_insert_and_prune(self):
+        root = py_trees.composites.Sequence(name="root", memory=True)
+        root.add_child(py_trees.behaviours.Running(name="forever"))
+        tree = py_trees.trees.BehaviourTree(root)
+        logger = self.build_logger(tree, self.clock)
+        tree.tick()
+
+        self.clock.value = 1.0
+        added = py_trees.behaviours.Running(name="added")
+        tree.insert_subtree(added, root.id, 1)
+        tree.tick()
+        _, events = self.read()
+        self.assertIn("added", {e["behavior_name"] for e in events})
+
+        self.clock.value = 2.0
+        tree.prune_subtree(added.id)
+        tree.tick()
+        logger.close()
+        _, events = self.read()
+        removed = [e for e in events if e.get("removed")]
+        self.assertEqual([e["behavior_id"] for e in removed], [str(added.id)])
+
+    def test_file_is_readable_after_an_abrupt_end(self):
+        # Every record is flushed, so a run killed mid-scenario still yields a
+        # parseable file -- exactly the run whose tree state is worth reading.
+        tree = self.simple_tree()
+        self.build_logger(tree, self.clock)
+        tree.tick()
+        meta, events = self.read()  # no close()
+        self.assertEqual(meta["format"], "behaviour_tree_log")
+        self.assertTrue(events)
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/scenario_execution/test/test_run_process.py
+++ b/scenario_execution/test/test_run_process.py
@@ -14,12 +14,15 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
+import os
+import signal
 import unittest
 import py_trees
 from scenario_execution import ScenarioExecution
+from scenario_execution.actions.run_process import RunProcess
 from scenario_execution.model.osc2_parser import OpenScenario2Parser
 from scenario_execution.model.model_to_py_tree import create_py_tree
-from scenario_execution.utils.logging import Logger
+from scenario_execution.utils.logging import BaseLogger, Logger
 from antlr4.InputStream import InputStream
 from datetime import datetime
 
@@ -117,3 +120,106 @@ scenario test_run_process:
         parsed_tree = self.parser.parse_input_stream(InputStream(scenario_content))
         model = self.parser.create_internal_model(parsed_tree, self.tree, "test.osc", False)
         self.tree = create_py_tree(model, self.tree, self.parser.logger, False)
+
+
+class RecordingLogger(BaseLogger):
+    """Keeps what was logged, so a test can assert that being ignored was said out loud."""
+
+    def __init__(self):
+        super().__init__('test', False)
+        self.messages = {'info': [], 'debug': [], 'warning': [], 'error': []}
+
+    def info(self, msg: str) -> None:
+        self.messages['info'].append(msg)
+
+    def debug(self, msg: str) -> None:
+        self.messages['debug'].append(msg)
+
+    def warning(self, msg: str) -> None:
+        self.messages['warning'].append(msg)
+
+    def error(self, msg: str) -> None:
+        self.messages['error'].append(msg)
+
+
+class TestRunProcessReinitialise(unittest.TestCase):
+    """A re-initialise must never spawn a second process over a running one.
+
+    py_trees re-initialises every child that is not RUNNING, so an action parked in SUCCESS
+    (``wait_for_shutdown: false``) is re-``initialise()``d -- and ``initialise()`` calls
+    ``execute()``. If ``update()`` then spawns again, ``self.process`` is rebound to the newborn and
+    the handle on the real child is lost: ``shutdown()`` signals the wrong process group, reports
+    success, and a simulator that writes its results only on a clean stop writes none. That is how a
+    stopping scenario orphaned its simulator and lost every run artifact.
+
+    ``execute()`` + ``update()`` are driven directly here: that pair is exactly what a re-initialise
+    performs, and it needs no ROS, no tick timer and no scenario file to reproduce.
+    """
+
+    def setUp(self) -> None:
+        self.logger = RecordingLogger()
+        self.action = RunProcess()
+        self.action._set_base_properities('test_run_process', None, self.logger)  # pylint: disable=protected-access
+        self.spawned_pids = []
+        self.addCleanup(self._kill_spawned)
+
+    def _kill_spawned(self):
+        # Reap everything the test started, including the extra process an unfixed action spawns --
+        # a leaked `sleep` would outlive the suite.
+        for pid in self.spawned_pids:
+            try:
+                os.killpg(os.getpgid(pid), signal.SIGKILL)
+            except (ProcessLookupError, PermissionError):
+                pass
+
+    def _reinitialise(self, command='sleep 30'):
+        """One initialise+update cycle, as py_trees performs it. Returns the action's status."""
+        self.action.execute(command, wait_for_shutdown=False)
+        status = self.action.update()
+        if self.action.process is not None and self.action.process.pid not in self.spawned_pids:
+            self.spawned_pids.append(self.action.process.pid)
+        return status
+
+    def test_reinitialise_keeps_the_running_process(self):
+        self.assertEqual(self._reinitialise(), py_trees.common.Status.SUCCESS)
+        first = self.action.process
+        self.assertIsNone(first.poll(), "the process under test should still be running")
+
+        self.assertEqual(self._reinitialise(), py_trees.common.Status.SUCCESS)
+
+        self.assertIs(self.action.process, first,
+                      "a re-initialise spawned a second process and dropped the handle on the first")
+        self.assertEqual(len(self.spawned_pids), 1, "exactly one process should have been spawned")
+
+    def test_shutdown_kills_the_process_that_was_started(self):
+        self._reinitialise()
+        started = self.action.process
+        self._reinitialise()
+
+        self.action.shutdown()
+
+        started.wait(10)
+        self.assertIsNotNone(started.poll(),
+                             "shutdown() must signal the process that is actually running")
+
+    def test_reinitialise_after_exit_starts_a_new_process(self):
+        # The guard must not turn into "an action can only ever run once".
+        self._reinitialise('true')
+        first = self.action.process
+        first.wait(10)
+        self.assertIsNotNone(first.poll())
+
+        self._reinitialise('true')
+
+        self.assertIsNot(self.action.process, first,
+                         "a finished process must not block a legitimate re-run")
+
+    def test_reinitialise_with_a_different_command_is_reported(self):
+        self._reinitialise('sleep 30')
+        first = self.action.process
+
+        self._reinitialise('sleep 31')
+
+        self.assertIs(self.action.process, first, "the running process must be kept")
+        self.assertTrue(any('sleep 31' in msg for msg in self.logger.messages['warning']),
+                        "ignoring a different command must be said out loud, not silently")

--- a/scenario_execution_ros/scenario_execution_ros/scenario_execution_ros.py
+++ b/scenario_execution_ros/scenario_execution_ros/scenario_execution_ros.py
@@ -22,8 +22,25 @@ import py_trees_ros
 from py_trees_ros_interfaces.srv import OpenSnapshotStream
 from scenario_execution import ScenarioExecution, ShutdownHandler
 from scenario_execution.scenario_execution_base import _load_simulation, _build_reset_kwargs
+from scenario_execution.simulation import Clock
 from .logging_ros import RosLogger
 from .marker_handler import MarkerHandler
+
+
+class RosClock(Clock):
+    """The ROS time source, as a scenario_execution Clock.
+
+    Implements the interface the framework already defines rather than adding a
+    ROS-specific path: with ``use_sim_time`` this is the /clock timeline, so a
+    behaviour-tree log recorded through it lines up with everything else in the run.
+    """
+
+    def __init__(self, node):
+        self._node = node
+        self._start = node.get_clock().now().nanoseconds / 1e9
+
+    def now(self) -> float:
+        return self._node.get_clock().now().nanoseconds / 1e9 - self._start
 
 
 class ROSScenarioExecution(ScenarioExecution):
@@ -54,6 +71,7 @@ class ROSScenarioExecution(ScenarioExecution):
         self.post_run = args.post_run
         self.snapshot_period = args.snapshot_period
         self.output_result_per_scenario = args.output_result_per_scenario
+        bt_log = args.bt_log
 
         # override commandline by ros parameters
         self.node.declare_parameter('debug', False)
@@ -67,6 +85,7 @@ class ROSScenarioExecution(ScenarioExecution):
         self.node.declare_parameter('create_scenario_parameter_file_template', False)
         self.node.declare_parameter('post_run', [""])
         self.node.declare_parameter('snapshot_period', 1.0)
+        self.node.declare_parameter('bt_log', False)
 
         if self.node.get_parameter('debug').value:
             debug = self.node.get_parameter('debug').value
@@ -91,6 +110,8 @@ class ROSScenarioExecution(ScenarioExecution):
             self.post_run = post_run_param
         if self.node.get_parameter('snapshot_period').value:
             self.snapshot_period = self.node.get_parameter('snapshot_period').value
+        if self.node.get_parameter('bt_log').value:
+            bt_log = self.node.get_parameter('bt_log').value
         self.logger = RosLogger('scenario_execution_ros', debug)
         # Optional step-based SimulationInterface (--simulation module:Class). The base ROS runner
         # historically ignored it; _run_single_scenario() below now drives its
@@ -108,6 +129,7 @@ class ROSScenarioExecution(ScenarioExecution):
                          post_run=self.post_run,
                          output_result_per_scenario=self.output_result_per_scenario,
                          simulation=simulation,
+                         bt_log=bt_log,
                          logger=self.logger)
 
     def setup_behaviour_tree(self, tree):
@@ -214,8 +236,12 @@ class ROSScenarioExecution(ScenarioExecution):
 
         try:
             try:
+                # sim_clock (not clock) so the behaviour-tree log gets ROS time without
+                # also retargeting ClockTimer/ClockTimeout, which would change when
+                # timeouts fire in every existing scenario.
                 self.setup(tree, current_output_dir=effective_output_dir,
-                           node=self.node, marker_handler=self.marker_handler)
+                           node=self.node, marker_handler=self.marker_handler,
+                           sim_clock=RosClock(self.node))
             except Exception as e:  # pylint: disable=broad-except
                 self.on_scenario_shutdown(False, "Setup failed", f"{e}")
                 return

--- a/scenario_execution_ros/scenario_execution_ros/scenario_execution_ros.py
+++ b/scenario_execution_ros/scenario_execution_ros/scenario_execution_ros.py
@@ -43,7 +43,7 @@ class RosClock(Clock):
         return self._node.get_clock().now().nanoseconds / 1e9 - self._start
 
 
-class InterruptibleBehaviourTree(py_trees_ros.trees.BehaviourTree):
+class InterruptibleBehaviorTree(py_trees_ros.trees.BehaviourTree):
     """A py_trees_ros tree whose ``interrupt()`` actually stops the ticking.
 
     py_trees' ``interrupt()`` sets ``interrupt_tick_tocking``, which its own blocking ``tick_tock``
@@ -166,9 +166,9 @@ class ROSScenarioExecution(ScenarioExecution):
             tree [py_trees.behaviour.Behaviour]: root of the behaviour tree
 
         return:
-            InterruptibleBehaviourTree
+            InterruptibleBehaviorTree
         """
-        return InterruptibleBehaviourTree(tree)
+        return InterruptibleBehaviorTree(tree)
 
     def post_setup(self):
         request = OpenSnapshotStream.Request()

--- a/scenario_execution_ros/scenario_execution_ros/scenario_execution_ros.py
+++ b/scenario_execution_ros/scenario_execution_ros/scenario_execution_ros.py
@@ -21,6 +21,7 @@ import rclpy  # pylint: disable=import-error
 import py_trees_ros
 from py_trees_ros_interfaces.srv import OpenSnapshotStream
 from scenario_execution import ScenarioExecution, ShutdownHandler
+from scenario_execution.scenario_execution_base import _load_simulation, _build_reset_kwargs
 from .logging_ros import RosLogger
 from .marker_handler import MarkerHandler
 
@@ -91,6 +92,10 @@ class ROSScenarioExecution(ScenarioExecution):
         if self.node.get_parameter('snapshot_period').value:
             self.snapshot_period = self.node.get_parameter('snapshot_period').value
         self.logger = RosLogger('scenario_execution_ros', debug)
+        # Optional step-based SimulationInterface (--simulation module:Class). The base ROS runner
+        # historically ignored it; _run_single_scenario() below now drives its
+        # setup/reset/step/shutdown inside the ROS spin loop (see run() docstring).
+        simulation = _load_simulation(args.simulation) if getattr(args, 'simulation', None) else None
         super().__init__(debug=debug,
                          log_model=log_model,
                          live_tree=live_tree,
@@ -102,6 +107,7 @@ class ROSScenarioExecution(ScenarioExecution):
                          create_scenario_parameter_file_template=self.create_scenario_parameter_file_template,
                          post_run=self.post_run,
                          output_result_per_scenario=self.output_result_per_scenario,
+                         simulation=simulation,
                          logger=self.logger)
 
     def setup_behaviour_tree(self, tree):
@@ -135,6 +141,14 @@ class ROSScenarioExecution(ScenarioExecution):
         down once, after the last scenario. With multiple scenarios (e.g. one per
         document of a multi-document ``--scenario-parameter-file``) each result is
         written into its own ``_output_dir`` by :meth:`process_results`.
+
+        When a step-based ``--simulation`` (SimulationInterface) is given, each
+        scenario additionally sets it up, resets it with the scenario parameters,
+        ticks ``simulation.step()`` inside the ROS spin loop, and shuts it down.
+        Unlike the non-ROS ``run_with_simulation`` (which the simulation drives
+        exclusively), here ROS behaviours run the scenario while the simulation
+        advances time (a simulation that publishes ``/clock`` becomes the time
+        source; other nodes run ``use_sim_time``).
         """
         self._aborted = False
         # The node created in __init__ is only needed to read ROS parameters; each
@@ -146,24 +160,29 @@ class ROSScenarioExecution(ScenarioExecution):
 
         try:
             multiple_scenarios = len(self.scenarios_list) > 1
-            for tree, _params, scenario_output_dir_override in self.scenarios_list:
+            for tree, params, scenario_output_dir_override in self.scenarios_list:
                 effective_output_dir = self._resolve_scenario_output_dir(
                     tree.name, scenario_output_dir_override, multiple_scenarios)
                 if effective_output_dir is None and multiple_scenarios and self.output_dir:
                     # Directory creation failed; failure already recorded.
                     continue
-                self._run_single_scenario(tree, effective_output_dir)
+                self._run_single_scenario(tree, effective_output_dir, params)
                 if self._aborted:
                     break
         finally:
             rclpy.shutdown()
 
-    def _run_single_scenario(self, tree, effective_output_dir):
+    def _run_single_scenario(self, tree, effective_output_dir, scenario_params=None):
         """Set up, tick and tear down one scenario's behaviour tree.
 
         Each scenario runs on its OWN ROS node and executor: py_trees_ros adopts
         the node it is given and destroys it on ``shutdown()``, so the node cannot
         be shared across scenarios.
+
+        If a step-based ``--simulation`` is configured it is set up and reset for
+        this scenario, stepped once per spin-loop iteration (paced to realtime),
+        and shut down afterwards -- so the simulation advances alongside the ROS
+        behaviours that drive it.
         """
         # Reset per-scenario async-shutdown state so the previous scenario's
         # tasks/futures do not leak into this one.
@@ -174,6 +193,24 @@ class ROSScenarioExecution(ScenarioExecution):
         self.marker_handler = MarkerHandler(self.node)
         executor = rclpy.executors.MultiThreadedExecutor()
         executor.add_node(self.node)
+
+        # Optional step-based SimulationInterface: build + reset it for this scenario. A simulation
+        # that publishes /clock on step() becomes the time source; other nodes run use_sim_time.
+        sim_dt = None
+        if self.simulation is not None:
+            try:
+                self.simulation.setup(logger=self.logger, output_dir=effective_output_dir,
+                                      tick_period=self.tick_period)
+                self.simulation.reset(**_build_reset_kwargs(self.simulation, scenario_params or {}))
+                sim_dt = self.simulation.dt
+            except Exception as e:  # pylint: disable=broad-except
+                self.on_scenario_shutdown(False, "Simulation setup failed", f"{e}")
+                self._shutdown_simulation()
+                try:
+                    self.node.destroy_node()
+                except Exception:  # pylint: disable=broad-except
+                    pass
+                return
 
         try:
             try:
@@ -186,9 +223,21 @@ class ROSScenarioExecution(ScenarioExecution):
             try:
                 self.behaviour_tree.tick_tock(period_ms=1000. * self.tick_period)
                 shutdown_done_time = None
+                next_step = time.perf_counter()
                 while rclpy.ok():
                     try:
-                        executor.spin_once(timeout_sec=self.tick_period)
+                        if self.simulation is not None:
+                            # Pace stepping to realtime (v1): step only once wall time has caught up,
+                            # and spin ROS in the gap so behaviour action feedback keeps flowing.
+                            # For faster-than-realtime, drop the `now >= next_step` gate.
+                            now = time.perf_counter()
+                            if now >= next_step:
+                                self.simulation.step()
+                                next_step += sim_dt
+                            executor.spin_once(
+                                timeout_sec=max(min(next_step - time.perf_counter(), sim_dt), 0.0))
+                        else:
+                            executor.spin_once(timeout_sec=self.tick_period)
                     except KeyboardInterrupt:
                         self._aborted = True
                         self.on_scenario_shutdown(False, "Aborted")
@@ -209,6 +258,7 @@ class ROSScenarioExecution(ScenarioExecution):
             finally:
                 # ensure behaviour tree threads are stopped before the next scenario
                 self._robust_tree_shutdown()
+                self._shutdown_simulation()
         finally:
             # py_trees_ros may already have destroyed the node during shutdown;
             # destroy_node() is idempotent-safe here (errors are ignored).
@@ -216,6 +266,15 @@ class ROSScenarioExecution(ScenarioExecution):
                 self.node.destroy_node()
             except Exception as e:  # pylint: disable=broad-except
                 self.logger.debug(f"Exception destroying scenario node: {e}")
+
+    def _shutdown_simulation(self):
+        """Shut down the step-based simulation for the current scenario, if any."""
+        if self.simulation is None:
+            return
+        try:
+            self.simulation.shutdown()
+        except Exception as e:  # pylint: disable=broad-except
+            self.logger.error(f"Simulation shutdown error: {e}")
 
     def shutdown(self):
         self.logger.info("Shutting down...")

--- a/scenario_execution_ros/scenario_execution_ros/scenario_execution_ros.py
+++ b/scenario_execution_ros/scenario_execution_ros/scenario_execution_ros.py
@@ -43,6 +43,31 @@ class RosClock(Clock):
         return self._node.get_clock().now().nanoseconds / 1e9 - self._start
 
 
+class InterruptibleBehaviourTree(py_trees_ros.trees.BehaviourTree):
+    """A py_trees_ros tree whose ``interrupt()`` actually stops the ticking.
+
+    py_trees' ``interrupt()`` sets ``interrupt_tick_tocking``, which its own blocking ``tick_tock``
+    loop checks every iteration. py_trees_ros re-implements ``tick_tock`` on an rclpy timer whose
+    callback never reads that flag, so ``interrupt()`` is a no-op here and the timer is stopped only
+    by ``shutdown()``.
+
+    That gap loses run artifacts. ``on_scenario_shutdown`` calls ``interrupt()`` and then schedules
+    ``shutdown()`` as an executor task, so between the two the timer keeps firing; py_trees
+    re-initialises every child that is not RUNNING, and an action parked in SUCCESS
+    (``wait_for_shutdown: false``) is re-``execute()``d. For ``ros_launch`` that used to spawn a
+    second ``ros2 launch``, which ``shutdown()`` then killed instead of the real one -- leaving the
+    simulator orphaned and its recording and run capture never written.
+
+    ``shutdown()`` cancels and destroys the same timer afterwards; cancelling twice is harmless, and
+    ``timer`` is ``None`` until ``tick_tock()`` runs, so interrupting before then is a no-op.
+    """
+
+    def interrupt(self):
+        if self.timer is not None:
+            self.timer.cancel()
+        super().interrupt()
+
+
 class ROSScenarioExecution(ScenarioExecution):
     """
     Class for scenario execution using ROS2 as middleware
@@ -141,9 +166,9 @@ class ROSScenarioExecution(ScenarioExecution):
             tree [py_trees.behaviour.Behaviour]: root of the behaviour tree
 
         return:
-            py_trees_ros.trees.BehaviourTree
+            InterruptibleBehaviourTree
         """
-        return py_trees_ros.trees.BehaviourTree(tree)
+        return InterruptibleBehaviourTree(tree)
 
     def post_setup(self):
         request = OpenSnapshotStream.Request()

--- a/scenario_execution_ros/setup.py
+++ b/scenario_execution_ros/setup.py
@@ -36,7 +36,7 @@ setup(
     ],
     install_requires=[
         'setuptools',
-        'transforms3d==0.4.1',
+        'transforms3d==0.4.2',  # 0.4.1 calls np.maximum_sctype, removed in NumPy 2.0
         'py-trees-ros==2.4.0',
     ],
     zip_safe=True,

--- a/scenario_execution_ros/test/test_interruptible_behavior_tree.py
+++ b/scenario_execution_ros/test/test_interruptible_behavior_tree.py
@@ -67,10 +67,11 @@ class TestInterruptibleBehaviorTree(unittest.TestCase):
 
     def _teardown(self):
         # The tree adopts the node and destroys it in shutdown(); guard against a test that already
-        # shut it down.
+        # shut it down. The catch is deliberately broad: cleanup must not mask the failure of the
+        # test that is on its way out.
         try:
             self.tree.shutdown()
-        except Exception:  # noqa: BLE001 - cleanup must not mask a test failure
+        except Exception:  # pylint: disable=broad-except
             pass
 
     def _spin(self, seconds):

--- a/scenario_execution_ros/test/test_interruptible_behavior_tree.py
+++ b/scenario_execution_ros/test/test_interruptible_behavior_tree.py
@@ -19,7 +19,7 @@ import unittest
 import py_trees
 import rclpy
 
-from scenario_execution_ros.scenario_execution_ros import InterruptibleBehaviourTree
+from scenario_execution_ros.scenario_execution_ros import InterruptibleBehaviorTree
 
 
 class Counter(py_trees.behaviour.Behaviour):
@@ -34,7 +34,7 @@ class Counter(py_trees.behaviour.Behaviour):
         return py_trees.common.Status.SUCCESS
 
 
-class TestInterruptibleBehaviourTree(unittest.TestCase):
+class TestInterruptibleBehaviorTree(unittest.TestCase):
     """``interrupt()`` must actually stop the rclpy-timer ticking.
 
     py_trees' ``interrupt()`` only sets ``interrupt_tick_tocking``, and py_trees_ros' timer callback
@@ -59,9 +59,9 @@ class TestInterruptibleBehaviourTree(unittest.TestCase):
             rclpy.shutdown()
 
     def setUp(self):
-        self.node = rclpy.create_node("test_interruptible_behaviour_tree")
+        self.node = rclpy.create_node("test_interruptible_behavior_tree")
         self.counter = Counter()
-        self.tree = InterruptibleBehaviourTree(self.counter)
+        self.tree = InterruptibleBehaviorTree(self.counter)
         self.tree.setup(node=self.node, timeout=10.0)
         self.addCleanup(self._teardown)
 

--- a/scenario_execution_ros/test/test_interruptible_behaviour_tree.py
+++ b/scenario_execution_ros/test/test_interruptible_behaviour_tree.py
@@ -1,0 +1,110 @@
+# Copyright (C) 2026 Frederik Pasch
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions
+# and limitations under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+import unittest
+
+import py_trees
+import rclpy
+
+from scenario_execution_ros.scenario_execution_ros import InterruptibleBehaviourTree
+
+
+class Counter(py_trees.behaviour.Behaviour):
+    """Reports SUCCESS and counts its ticks, so a test can tell whether ticking stopped."""
+
+    def __init__(self):
+        super().__init__(name="counter")
+        self.ticks = 0
+
+    def update(self):
+        self.ticks += 1
+        return py_trees.common.Status.SUCCESS
+
+
+class TestInterruptibleBehaviourTree(unittest.TestCase):
+    """``interrupt()`` must actually stop the rclpy-timer ticking.
+
+    py_trees' ``interrupt()`` only sets ``interrupt_tick_tocking``, and py_trees_ros' timer callback
+    never reads it -- so on the plain class the ticks continue and a scenario that has asked to shut
+    down keeps re-initialising its actions. That is what re-spawned ``ros2 launch`` during teardown
+    and orphaned the simulator, losing the run's recording and capture.
+    """
+
+    @classmethod
+    def setUpClass(cls):
+        # rclpy's context is global, and a sibling test module in the same pytest run may already
+        # own it. Only init (and only shut down) what this class actually brought up, or the two
+        # collide: whichever ran second would fail on an already-initialised context, and whichever
+        # shut down first would pull the context out from under the other.
+        cls._owns_context = not rclpy.ok()
+        if cls._owns_context:
+            rclpy.init()
+
+    @classmethod
+    def tearDownClass(cls):
+        if cls._owns_context:
+            rclpy.shutdown()
+
+    def setUp(self):
+        self.node = rclpy.create_node("test_interruptible_behaviour_tree")
+        self.counter = Counter()
+        self.tree = InterruptibleBehaviourTree(self.counter)
+        self.tree.setup(node=self.node, timeout=10.0)
+        self.addCleanup(self._teardown)
+
+    def _teardown(self):
+        # The tree adopts the node and destroys it in shutdown(); guard against a test that already
+        # shut it down.
+        try:
+            self.tree.shutdown()
+        except Exception:  # noqa: BLE001 - cleanup must not mask a test failure
+            pass
+
+    def _spin(self, seconds):
+        end = self.node.get_clock().now().nanoseconds + seconds * 1e9
+        while self.node.get_clock().now().nanoseconds < end:
+            rclpy.spin_once(self.node, timeout_sec=0.01)
+
+    def test_interrupt_stops_the_ticking(self):
+        self.tree.tick_tock(period_ms=50.0)
+        self._spin(0.3)
+        self.assertGreater(self.counter.ticks, 0, "the tree should have been ticking")
+
+        self.tree.interrupt()
+        ticks_at_interrupt = self.counter.ticks
+        self._spin(0.3)
+
+        self.assertEqual(self.counter.ticks, ticks_at_interrupt,
+                         "interrupt() must stop the tick timer; a tick after shutdown was requested "
+                         "re-initialises actions and re-spawns their processes")
+
+    def test_interrupt_still_sets_the_py_trees_flag(self):
+        # The base-class contract has to keep working: a non-ROS tick_tock loop reads this flag.
+        self.tree.tick_tock(period_ms=50.0)
+        self.tree.interrupt()
+        self.assertTrue(self.tree.interrupt_tick_tocking)
+
+    def test_interrupt_before_tick_tock_is_a_noop(self):
+        # `timer` is None until tick_tock() runs; interrupting then must not raise.
+        self.assertIsNone(self.tree.timer)
+        self.tree.interrupt()
+
+    def test_shutdown_after_interrupt_is_safe(self):
+        # shutdown() cancels and destroys the same timer; doing it after interrupt() must not raise.
+        self.tree.tick_tock(period_ms=50.0)
+        self._spin(0.1)
+        self.tree.interrupt()
+        self.tree.shutdown()

--- a/test/scenario_execution_nav2_test/scenarios/test_scenario_execution_nav2.osc
+++ b/test/scenario_execution_nav2_test/scenarios/test_scenario_execution_nav2.osc
@@ -9,7 +9,7 @@ scenario example_nav2:
         ros_launch("nav2_bringup", "tb4_loopback_simulation.launch.py", [
                     key_value('map', ament.get_package_share_directory("tb4_sim_scenario") + "/maps/maze.yaml")
                 ], wait_for_shutdown: false)
-        bag_record(['/tf', '/tf_static', '/scenario_execution/snapshots', '/map', '/local_costmap/costmap'], use_sim_time: true)
+        bag_record(['/tf', '/tf_static', '/map', '/local_costmap/costmap'], use_sim_time: true)
         robot.init_nav2(pose_3d(position_3d(x: 0.0m, y: 0.0m)), wait_for_amcl: false)
         serial:
             repeat(2)


### PR DESCRIPTION
### Description
Adds a middleware-independent behavior tree status log, lets the ROS runner drive a
step-based simulation, fixes process shutdown in a stopping scenario, and aligns the
base logger's line format with the ROS one.

Issue Number: #<XXX>

### Pull request checklist
- [ ] [Issue](https://github.com/cps-test-lab/scenario-execution/issues) created that explains the change and why it's needed
- [x] Tests are part of the PR (for bug fixes / features)
- [x] [Docs](https://cps-test-lab.github.io/scenario-execution/) reviewed and added / updated if needed (for bug fixes / features)
- [ ] Format and Lint checks (`make check`) pass locally
- [x] PR applies Apache 2.0 License to all code files

### Pull request type
- [x] Feature

### Current behavior
- Tracking what the behavior tree did required recording `/scenario_execution/snapshots`
  into a rosbag. Scenarios run through the plain runner had no way to capture it at all.
- `--simulation` was honoured only by the non-ROS runner (`run_with_simulation`), which has
  no `rclpy` and therefore cannot run ROS behaviors — so a step-based simulator could not
  drive a ROS stack.
- A scenario shutting down could lose the handle to a `run_process` child before killing it.
- `Logger` printed `[name] [LEVEL] msg` while `RosLogger` printed `[LEVEL] [epoch] [name]: msg`,
  so a scenario's own output could only be placed in time depending on the middleware in use.
- `transforms3d==0.4.1` calls `np.maximum_sctype`, removed in NumPy 2.0.

### New behavior
- **`--bt-log`** writes `<output-dir>/behaviors.jsonl` (JSON Lines) from the base runner, so
  the ROS runner inherits it. The whole tree is written once at `timestamp` 0 and only status
  changes after that; records carry `osc_file`/`osc_line`/`osc_column`. Needs no middleware.
- **Step-based simulation with the ROS runner:** the spin loop additionally ticks
  `simulation.step()`, so the simulation advances alongside the ROS behaviors driving it.
  Lifecycle is per scenario, since each scenario runs on its own node.
- **`run_process`** keeps hold of the process it is about to kill during shutdown.
- **Log lines are uniform:** both loggers now emit `[LEVEL] [epoch] [name]: msg`.
  ⚠️ This changes the base runner's output — anything parsing `scenario_execution`'s stdout
  needs updating. `scenario_execution_ros` already had this shape.
- `transforms3d==0.4.2`, so NumPy 2 works.

### How to test
```bash
colcon build
colcon test --packages-select scenario_execution scenario_execution_ros
```
New tests: `test_bt_logger.py`, `test_run_process.py`, `test_interruptible_behavior_tree.py`.

For the log manually:
```bash
scenario_execution <scenario.osc> --output-dir out --bt-log
head -2 out/behaviors.jsonl
```
