### PR TITLE
Upgrade base packages when building the images, fixing the nav2 jobs

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -36,8 +36,12 @@ RUN chmod +x /ros_entrypoint.sh
 ##                      Scenario Execution Dependencies                     ##
 ##############################################################################
 
+# Upgrade before installing, for the same reason as in .github/workflows/Dockerfile.testing: the
+# base image is a snapshot and rosdep installs from the current repository.
+# hadolint ignore=DL3005
 RUN --mount=type=bind,target=/tmp_setup export DEBIAN_FRONTEND=noninteractive && \
     apt-get update && \
+    apt-get upgrade -y && \
     xargs -a /tmp_setup/deb_requirements.txt apt-get install -y --no-install-recommends && \
     xargs -a /tmp_setup/libs/scenario_execution_kubernetes/deb_requirements.txt apt-get install -y --no-install-recommends && \
     rosdep update --rosdistro="${ROS_DISTRO}" && \

--- a/.github/workflows/Dockerfile.production
+++ b/.github/workflows/Dockerfile.production
@@ -4,9 +4,12 @@ FROM osrf/ros:${ROS_DISTRO}-desktop-full
 SHELL ["/bin/bash", "-xo", "pipefail", "-c"]
 
 # Install system dependencies
-# hadolint ignore=DL3008
+# Upgrade before installing, for the same reason as in Dockerfile.testing: the base image is a
+# snapshot and rosdep installs from the current repository.
+# hadolint ignore=DL3005,DL3008
 RUN --mount=type=bind,source=.,target=/scenario_execution \
     apt-get update && \
+    apt-get upgrade -y && \
     apt-get install -y --no-install-recommends \
         python3-pip && \
     xargs -a /scenario_execution/deb_requirements.txt apt-get install -y --no-install-recommends && \

--- a/.github/workflows/Dockerfile.testing
+++ b/.github/workflows/Dockerfile.testing
@@ -4,9 +4,13 @@ FROM osrf/ros:${ROS_DISTRO}-desktop-full
 SHELL ["/bin/bash", "-xo", "pipefail", "-c"]
 
 # Install system dependencies
-# hadolint ignore=DL3008
+# The base image is a snapshot, while rosdep installs from the current repository. Upgrading first
+# keeps both from the same sync -- without it, a freshly pulled package can be linked against a
+# newer library than the one the base image froze, which fails at load time, not at build time.
+# hadolint ignore=DL3005,DL3008
 RUN --mount=type=bind,source=.,target=/scenario_execution \
     apt-get update && \
+    apt-get upgrade -y && \
     apt-get install -y --no-install-recommends \
         python3-pip \
         python3-setuptools \


### PR DESCRIPTION
### Description
Upgrade base packages when building the container images, fixing `test-example-nav2` and `test-scenario-execution-nav2`.

Issue Number: #<XXX>

### Pull request checklist
- [ ] [Issue](https://github.com/cps-test-lab/scenario-execution/issues) created that explains the change and why it's needed
- [ ] Tests are part of the PR (for bug fixes / features)
- [ ] [Docs](https://cps-test-lab.github.io/scenario-execution/) reviewed and added / updated if needed (for bug fixes / features)
- [ ] Format and Lint checks (`make check`) pass locally
- [x] PR applies Apache 2.0 License to all code files

### Pull request type
- [x] Build related changes

### Current behavior
Both nav2 jobs have failed since 2026-06-29, while every other job passes. `nav2_lifecycle_manager` dies at startup with exit code 127:

```
libnav2_lifecycle_manager_core.so: undefined symbol:
_ZN18diagnostic_updater7UpdaterC1E...NodeTopicsInterfaceEEdh
```

That is `diagnostic_updater::Updater::Updater(node interfaces..., double, unsigned char)`. It happens in both jobs — standalone in `test-scenario-execution-nav2`, and inside `nav2_container` in `test-example-nav2`.

With the lifecycle manager dead, nothing activates the lifecycle nodes. `map_server` reports "Waiting on external lifecycle transitions to activate" and stays there, so `/map` and `/local_costmap/costmap` are never published and `bag_record` waits for them until the scenario times out. The visible symptom is the wait; the cause is a process that died seconds earlier.

The images build `FROM osrf/ros:${ROS_DISTRO}-desktop-full`, a snapshot, and then `rosdep install` pulls from the current repository. nav2 is fetched fresh while `diagnostic_updater` stays at the version the base image froze, and nothing forces an upgrade because the dependency carries no version constraint.

### New behavior
`apt-get upgrade` runs before the dependency install, keeping the image on one package sync.

This addresses the class, not the single symbol: any package rebuilt against a newer library fails the same way, and it fails at load time rather than at build time — which is why this surfaced as a scenario timeout rather than an image build error.

`DL3005` is ignored deliberately. Its advice against upgrading suits images pinned by their base; here the base is combined with packages from a moving repository, and pinning only one side is what breaks. All three images share the base-plus-rosdep pattern, so all three are changed.

### How to test
CI is the test: `Dockerfile.testing` is in `IMAGE_AFFECTING_PATTERNS`, so this PR rebuilds the testing image rather than reusing the cached `:latest` that carries the mismatch. `test-example-nav2` and `test-scenario-execution-nav2` should both go green.

The fix was checked at the symbol level beforehand — `ros-jazzy-diagnostic-updater` 4.2.7 in the repository does export the constructor nav2 is missing:

```
$ nm -D --defined-only libdiagnostic_updater.so | grep 7UpdaterC | c++filt
diagnostic_updater::Updater::Updater(..., double, unsigned char)
```

Both packages come from the same 2026-06-15 sync and are consistent with each other; the newer `diagnostic_updater` simply never got installed.
