### PR TITLE
Extend the introspection interface: get_action_details, describe_scenario, and a standalone MCP server

### DIFF
--- a/libs/scenario_execution_floorplan_dsl/scenario_execution_floorplan_dsl/lib_osc/floorplan_dsl.osc
+++ b/libs/scenario_execution_floorplan_dsl/scenario_execution_floorplan_dsl/lib_osc/floorplan_dsl.osc
@@ -1,14 +1,17 @@
 import osc.types
 
 actor floorplan_generator:
+    # Compiles a floorplan sketch into mesh/map assets and a runnable Gazebo world.
     result: string
     var generated_floorplan_mesh_path: string
     var generated_floorplan_map_path: string
     var generated_gazebo_world_path: string
 
 action floorplan_generator.generate_floorplan:
+    # Compile a .floorplan sketch into a mesh + map, exposed as generated_floorplan_mesh_path/generated_floorplan_map_path.
     file_path: string
 
 action floorplan_generator.generate_gazebo_world:
+    # Render an SDF Xacro template (with key_value substitutions) into a Gazebo world, exposed as generated_gazebo_world_path.
     sdf_template: string
     arguments: list of key_value

--- a/libs/scenario_execution_mcp/package.xml
+++ b/libs/scenario_execution_mcp/package.xml
@@ -1,0 +1,21 @@
+<?xml version="1.0"?>
+<?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
+<package format="3">
+  <name>scenario_execution_mcp</name>
+  <version>1.5.0</version>
+  <description>Standalone MCP server exposing scenario_execution's introspection module (list-actions, describe) as tools, for a client with no scenario-execution knowledge of its own.</description>
+  <author email="fred-labs@mailbox.org">Frederik Pasch</author>
+  <maintainer email="fred-labs@mailbox.org">Frederik Pasch</maintainer>
+  <license>Apache-2.0</license>
+
+  <depend>scenario_execution</depend>
+
+  <test_depend>ament_copyright</test_depend>
+  <test_depend>ament_flake8</test_depend>
+  <test_depend>ament_pep257</test_depend>
+  <test_depend>python3-pytest</test_depend>
+
+  <export>
+    <build_type>ament_python</build_type>
+  </export>
+</package>

--- a/libs/scenario_execution_mcp/scenario_execution_mcp/__init__.py
+++ b/libs/scenario_execution_mcp/scenario_execution_mcp/__init__.py
@@ -1,0 +1,15 @@
+# Copyright (C) 2026 Frederik Pasch
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions
+# and limitations under the License.
+#
+# SPDX-License-Identifier: Apache-2.0

--- a/libs/scenario_execution_mcp/scenario_execution_mcp/__main__.py
+++ b/libs/scenario_execution_mcp/scenario_execution_mcp/__main__.py
@@ -1,0 +1,20 @@
+# Copyright (C) 2026 Frederik Pasch
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions
+# and limitations under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+from scenario_execution_mcp.mcp_server import main
+
+if __name__ == "__main__":
+    main()

--- a/libs/scenario_execution_mcp/scenario_execution_mcp/mcp_server.py
+++ b/libs/scenario_execution_mcp/scenario_execution_mcp/mcp_server.py
@@ -1,0 +1,51 @@
+# Copyright (C) 2026 Frederik Pasch
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions
+# and limitations under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""A real MCP server for ``scenario_execution.introspection`` -- for use *without*
+robovast at all.
+
+The JSON CLI (``python -m scenario_execution.introspection ...``) answers "what does
+this container have" from a shell, but not from an MCP client. This registers the exact
+same functions as MCP tools -- no new logic, just a second, equally thin adapter, the
+same one-line pattern robovast's own MCP plugins use to register theirs.
+
+Runnable via ``python -m scenario_execution_mcp`` or the ``scenario_execution_mcp``
+console script (stdio transport), so anyone with a shell in the image -- not just
+robovast, and not needing this package's own dependents to have ever heard of
+``fastmcp`` -- can point an MCP client at it directly.
+"""
+
+from fastmcp import FastMCP
+
+from scenario_execution.introspection import (describe_scenario, get_action_details,
+                                              list_actions, validate)
+
+_TOOLS = [list_actions, get_action_details, describe_scenario, validate]
+
+
+def create_server() -> FastMCP:
+    mcp = FastMCP("scenario_execution")
+    for fn in _TOOLS:
+        mcp.tool()(fn)
+    return mcp
+
+
+def main() -> None:
+    create_server().run()
+
+
+if __name__ == "__main__":
+    main()

--- a/libs/scenario_execution_mcp/setup.cfg
+++ b/libs/scenario_execution_mcp/setup.cfg
@@ -1,0 +1,4 @@
+[develop]
+script_dir=$base/lib/scenario_execution_mcp
+[install]
+install_scripts=$base/lib/scenario_execution_mcp

--- a/libs/scenario_execution_mcp/setup.py
+++ b/libs/scenario_execution_mcp/setup.py
@@ -1,0 +1,47 @@
+# Copyright (C) 2026 Frederik Pasch
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions
+# and limitations under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+from setuptools import find_namespace_packages, setup
+
+PACKAGE_NAME = 'scenario_execution_mcp'
+
+setup(
+    name=PACKAGE_NAME,
+    version='1.5.0',
+    packages=find_namespace_packages(),
+    data_files=[
+        ('share/ament_index/resource_index/packages',
+            ['resource/' + PACKAGE_NAME]),
+        ('share/' + PACKAGE_NAME, ['package.xml'])
+    ],
+    install_requires=['setuptools', 'scenario_execution', 'fastmcp'],
+    zip_safe=True,
+    maintainer='Frederik Pasch',
+    maintainer_email='fred-labs@mailbox.org',
+    description=(
+        'Standalone MCP server exposing scenario_execution.introspection '
+        '(list-actions, describe) as tools -- usable by any MCP client with a shell '
+        'in the image, not just robovast.'
+    ),
+    license='Apache License 2.0',
+    tests_require=['pytest'],
+    include_package_data=True,
+    entry_points={
+        'console_scripts': [
+            'scenario_execution_mcp = scenario_execution_mcp.mcp_server:main',
+        ],
+    },
+)

--- a/libs/scenario_execution_mcp/test/test_mcp_server.py
+++ b/libs/scenario_execution_mcp/test/test_mcp_server.py
@@ -1,0 +1,67 @@
+# Copyright (C) 2026 Frederik Pasch
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions
+# and limitations under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""The standalone MCP server registers scenario_execution.introspection's own functions,
+unchanged -- this confirms the registration, not the introspection logic itself (covered
+by scenario_execution's own test_introspection.py)."""
+
+import asyncio
+import json
+import unittest
+
+from scenario_execution_mcp.mcp_server import create_server
+
+
+def _run(coro):
+    return asyncio.run(coro)
+
+
+class TestMcpServer(unittest.TestCase):
+
+    def test_all_four_tools_are_registered(self):
+        async def _names():
+            return {t.name for t in await create_server().list_tools()}
+
+        names = _run(_names())
+        self.assertEqual(
+            names, {"list_actions", "get_action_details", "describe_scenario", "validate"})
+
+    def test_list_actions_reflects_the_real_environment(self):
+        """Mirrors test_introspection.py's own TestListActions assertion -- same function,
+        reached through the MCP tool call this time, not a direct Python import."""
+        async def _call():
+            server = create_server()
+            result = await server.call_tool("list_actions", {})
+            return result
+
+        result = _run(_call())
+        catalog = json.loads(result.content[0].text)
+        log = next((a for a in catalog["actions"] if a["name"] == "log"), None)
+        self.assertIsNotNone(log, "expected the 'log' action from osc.helpers")
+        self.assertTrue(log["resolvable"])
+
+    def test_get_action_details_unknown_name_is_error(self):
+        async def _call():
+            server = create_server()
+            return await server.call_tool("get_action_details", {"name": "nope_xyz"})
+
+        result = _run(_call())
+        payload = json.loads(result.content[0].text)
+        self.assertIn("error", payload)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/libs/scenario_execution_pybullet/scenario_execution_pybullet/lib_osc/pybullet.osc
+++ b/libs/scenario_execution_pybullet/scenario_execution_pybullet/lib_osc/pybullet.osc
@@ -4,6 +4,7 @@ import osc.robotics
 actor simulation_pybullet
 
 action simulation_pybullet.initialize:
+    # Connect to PyBullet, set gravity, and load the world from a URDF file.
     world: string
 
 action simulation_pybullet.run
@@ -11,10 +12,12 @@ action simulation_pybullet.run
 actor actor_pybullet
 
 action actor_pybullet.spawn:
+    # Spawn this actor's body into the running PyBullet simulation at a pose.
     model: string
     pose: pose_3d
 
 action actor_pybullet.set_joint_motor_control:
+    # Drive every joint of this actor to a target velocity, bounded by a maximum force.
     target_velocity: speed
     force: float
 

--- a/scenario_execution/scenario_execution/introspection.py
+++ b/scenario_execution/scenario_execution/introspection.py
@@ -109,7 +109,72 @@ def _syntax_diagnostics(message, file):
     return diagnostics
 
 
-def validate(file_path, level="full", debug=False):  # pylint: disable=too-many-return-statements
+def _run_pipeline(file_path, level="full", debug=False):  # pylint: disable=too-many-return-statements
+    """Shared implementation behind :func:`validate` and :func:`describe_scenario`.
+
+    Runs the same parse/resolve pipeline ``validate()`` documents, but — unlike
+    ``validate()`` — also hands back the py-tree object phase 2 built (or ``None``
+    if nothing was built), since ``describe_scenario()`` needs the tree itself, not
+    just diagnostics about it. ``validate()`` stays a thin wrapper around this that
+    discards the tree, so its public return shape is untouched.
+
+    Returns ``(tree_or_None, diagnostics, valid)``.
+    """
+    # Imported lazily: importing the parser pulls in py_trees and the whole model
+    # stack, which is unnecessary for list_actions and slow to import.
+    # pylint: disable=import-outside-toplevel
+    from scenario_execution.model.error import OSC2Error
+    from scenario_execution.model.osc2_parser import OpenScenario2Parser
+    # pylint: enable=import-outside-toplevel
+
+    logger = _StderrLogger('scenario_execution', debug)
+    parser = OpenScenario2Parser(logger)
+
+    if not os.path.isfile(file_path):
+        return None, [_diagnostic(f"scenario file not found: {file_path}",
+                                  file=file_path, phase="syntax")], False
+
+    # Phase 1: syntax (ANTLR parse). Raises ValueError with newline-joined
+    # "line L:C msg" entries.
+    try:
+        parser.parse_file(file_path)
+    except ValueError as e:
+        return None, _syntax_diagnostics(e, file_path), False
+    except Exception as e:  # pylint: disable=broad-except  # report, never raise
+        return None, [_diagnostic(str(e), file=file_path, phase="syntax")], False
+
+    if level == "syntax":
+        return None, [], True
+
+    # Phase 2: full model build + semantic resolution + py-tree creation. The
+    # latter is where action/plugin resolution happens (name lookup, BaseAction
+    # subclass check, osc-vs-__init__/execute signature match), so we run the
+    # whole pipeline to catch those. OSC2Error carries an osc_ctx
+    # (line, column, text, file); ModelBuilder wraps some into ValueError.
+    try:
+        results = parser.process_file(file_path)
+    except OSC2Error as e:
+        line = column = None
+        ctx_file = file_path
+        if e.osc_ctx and len(e.osc_ctx) == 4:
+            line, column, _text, ctx_file = e.osc_ctx
+        return None, [_diagnostic(e.msg, line=line, column=column,
+                                  file=ctx_file or file_path,
+                                  phase="semantic")], False
+    except Exception as e:  # pylint: disable=broad-except  # report, never raise
+        line, column = _extract_ctx(e)
+        return None, [_diagnostic(str(e), line=line, column=column,
+                                  file=file_path, phase="semantic")], False
+
+    # process_file() returns one (py_tree, params, output_dir) tuple per scenario
+    # declared in the file; a describe_scenario() caller wants the tree of "the"
+    # scenario, so take the first one (the overwhelmingly common case is a single
+    # ScenarioDeclaration per file, as validate()'s own docstring assumes too).
+    tree = results[0][0] if results else None
+    return tree, [], True
+
+
+def validate(file_path, level="full", debug=False):
     """Validate an OpenSCENARIO 2 ``.osc`` file, returning structured diagnostics.
 
     Runs the same pipeline the engine uses at launch — ANTLR parse (syntax) plus
@@ -135,65 +200,21 @@ def validate(file_path, level="full", debug=False):  # pylint: disable=too-many-
     diagnostic is ``{severity, line, column, message, file, phase}`` and ``phase``
     is ``"syntax"`` or ``"semantic"``.
     """
-    # Imported lazily: importing the parser pulls in py_trees and the whole model
-    # stack, which is unnecessary for list_actions and slow to import.
-    # pylint: disable=import-outside-toplevel
-    from scenario_execution.model.error import OSC2Error
-    from scenario_execution.model.osc2_parser import OpenScenario2Parser
-    # pylint: enable=import-outside-toplevel
-
-    logger = _StderrLogger('scenario_execution', debug)
-    parser = OpenScenario2Parser(logger)
-
-    if not os.path.isfile(file_path):
-        return {"valid": False,
-                "diagnostics": [_diagnostic(f"scenario file not found: {file_path}",
-                                            file=file_path, phase="syntax")]}
-
-    # Phase 1: syntax (ANTLR parse). Raises ValueError with newline-joined
-    # "line L:C msg" entries.
-    try:
-        parser.parse_file(file_path)
-    except ValueError as e:
-        return {"valid": False, "diagnostics": _syntax_diagnostics(e, file_path)}
-    except Exception as e:  # pylint: disable=broad-except  # report, never raise
-        return {"valid": False,
-                "diagnostics": [_diagnostic(str(e), file=file_path, phase="syntax")]}
-
-    if level == "syntax":
-        return {"valid": True, "diagnostics": []}
-
-    # Phase 2: full model build + semantic resolution + py-tree creation. The
-    # latter is where action/plugin resolution happens (name lookup, BaseAction
-    # subclass check, osc-vs-__init__/execute signature match), so we run the
-    # whole pipeline to catch those. OSC2Error carries an osc_ctx
-    # (line, column, text, file); ModelBuilder wraps some into ValueError.
-    try:
-        parser.process_file(file_path)
-    except OSC2Error as e:
-        line = column = None
-        ctx_file = file_path
-        if e.osc_ctx and len(e.osc_ctx) == 4:
-            line, column, _text, ctx_file = e.osc_ctx
-        return {"valid": False,
-                "diagnostics": [_diagnostic(e.msg, line=line, column=column,
-                                            file=ctx_file or file_path,
-                                            phase="semantic")]}
-    except Exception as e:  # pylint: disable=broad-except  # report, never raise
-        line, column = _extract_ctx(e)
-        return {"valid": False,
-                "diagnostics": [_diagnostic(str(e), line=line, column=column,
-                                            file=file_path, phase="semantic")]}
-
-    return {"valid": True, "diagnostics": []}
+    _tree, diagnostics, valid = _run_pipeline(file_path, level=level, debug=debug)
+    return {"valid": valid, "diagnostics": diagnostics}
 
 
 # ── Action / declaration catalog ──────────────────────────────────────────────
 
 # A top-level declaration begins in column 0. We capture the kinds an LLM needs
-# to know to author scenarios.
+# to know to author scenarios. The name allows internal dots ("actor.method")
+# since that's how an action is qualified by the actor type it belongs to
+# (e.g. "differential_drive_robot.follow_waypoints") — matching only [A-Za-z_]\w*
+# here would truncate every such name at the first dot and collapse every
+# action on one actor type into a single (kind, name) key, silently dropping
+# all but the first from the catalog via list_actions()'s seen-key dedup.
 _DECL_RE = re.compile(
-    r"^(action|modifier|actor|struct|scenario|enum|global)\s+([A-Za-z_]\w*)")
+    r"^(action|modifier|actor|struct|scenario|enum|global)\s+([A-Za-z_][\w.]*)")
 # An indented parameter line: "name: type [= default] [# comment]".
 _PARAM_RE = re.compile(
     r"^\s+([A-Za-z_]\w*)\s*:\s*([^=#]+?)\s*(?:=\s*(.+?))?\s*(?:#\s*(.*))?$")
@@ -329,6 +350,158 @@ def list_actions():
     return catalog
 
 
+def get_action_details(name):
+    """One action/modifier/actor/struct's full catalog entry, or an error.
+
+    ``list_actions()`` filtered down to a single item by name, across all four
+    buckets — no new parsing; this exists so a caller who already knows a name
+    (from ``describe_scenario`` or elsewhere) can fetch its detail without
+    re-scanning the whole environment for context it will only use once.
+
+    Returns the item's dict (as documented in :func:`list_actions`), or
+    ``{"error": "..."}`` if *name* is not in any bucket.
+    """
+    catalog = list_actions()
+    for bucket in catalog.values():
+        for decl in bucket:
+            if decl["name"] == name:
+                return decl
+    return {"error": f"no action, modifier, actor or struct named {name!r} in this environment"}
+
+
+# ── Scenario usage: what does *this* file reference, and what did it build? ───
+
+# Actor variable declarations at scenario scope: "name: type" (no '=', no trailing
+# comment consumed as a param doc — this is a plain type binding, not a parameter
+# line). Reused to map an instance-qualified call ("robot.nav_to_pose(...)") back
+# to the catalog name ("differential_drive_robot.nav_to_pose") its type declares.
+_ACTOR_DECL_RE = re.compile(r"^\s*([A-Za-z_]\w*)\s*:\s*([A-Za-z_]\w*)\s*$")
+# A call site: a dotted-or-plain identifier immediately followed by '('. Matches
+# action calls ("robot.nav_to_pose("), bare modifier/action calls ("timeout(",
+# "log("), and struct constructors ("pose_3d(") alike — the catalog lookup below
+# is what tells them apart (kind: action/modifier/struct/actor).
+_CALL_RE = re.compile(r"\b([A-Za-z_]\w*(?:\.[A-Za-z_]\w*)*)\s*\(")
+
+
+def _scan_actions_used(file_path, catalog):
+    """Every action/modifier/actor/struct name *referenced* in `file_path`'s text.
+
+    Deliberately a text scan, not a walk of the resolved model: semantic
+    resolution aborts at the first unresolved reference (see :func:`validate`'s
+    docstring), so anything declared after a bad reference would never be
+    visited if this walked the model instead — a scenario with one typo would
+    silently under-report everything past it. A text scan sees every reference
+    regardless of whether the file resolves at all.
+
+    Handles instance-qualified calls (``robot.nav_to_pose(...)`` where
+    ``robot: differential_drive_robot`` was declared earlier in the same file)
+    by substituting the instance's declared type, since the catalog indexes
+    actions by their declaring actor's *type*, not by a scenario's local
+    instance names.
+    """
+    try:
+        with open(file_path, encoding="utf-8") as handle:
+            text = handle.read()
+    except OSError:
+        return []
+
+    instance_types = {}
+    for line in text.splitlines():
+        match = _ACTOR_DECL_RE.match(line)
+        if match:
+            instance_types[match.group(1)] = match.group(2)
+
+    lookup = {}
+    for bucket_name, bucket in catalog.items():
+        kind_singular = bucket_name[:-1] if bucket_name.endswith("s") else bucket_name
+        for decl in bucket:
+            lookup[decl["name"]] = (kind_singular, decl)
+
+    found = {}
+    for match in _CALL_RE.finditer(text):
+        raw_name = match.group(1)
+        head, _, rest = raw_name.partition(".")
+        candidates = [raw_name]
+        if head in instance_types and rest:
+            candidates.insert(0, f"{instance_types[head]}.{rest}")
+        for candidate in candidates:
+            if candidate in found:
+                break
+            if candidate in lookup:
+                kind, decl = lookup[candidate]
+                found[candidate] = {
+                    "name": candidate, "kind": kind, "doc": decl.get("doc"),
+                    "resolvable": decl.get("resolvable", True),
+                }
+                break
+        else:
+            # Not in the catalog under any candidate spelling: still worth
+            # surfacing (this is very likely the reason the file doesn't
+            # resolve), with the plain call-site spelling and no guessed kind.
+            if raw_name not in found:
+                found[raw_name] = {
+                    "name": raw_name, "kind": "action", "doc": None, "resolvable": False,
+                }
+
+    return sorted(found.values(), key=lambda item: item["name"])
+
+
+def _tree_to_json(node):
+    """Recurse a py-tree node's own `.children`/`.name` into `{name, type, children}`.
+
+    Not `py_trees.display.unicode_tree` — that renders human-readable ASCII, which
+    a caller would have to re-parse to recover structure this already has for
+    free by walking the tree object directly. Every py_trees node (composite,
+    decorator, or leaf behaviour) exposes `.name` and `.children` generically via
+    `py_trees.behaviour.Behaviour`, so no per-kind special-casing is needed beyond
+    picking a readable `type` label.
+    """
+    import py_trees  # pylint: disable=import-outside-toplevel
+
+    if isinstance(node, py_trees.composites.Sequence):
+        node_type = "sequence"
+    elif isinstance(node, py_trees.composites.Parallel):
+        node_type = "parallel"
+    elif isinstance(node, py_trees.composites.Selector):
+        node_type = "selector"
+    elif isinstance(node, py_trees.decorators.Decorator):
+        node_type = "modifier"
+    else:
+        node_type = "action"
+
+    result = {"name": node.name, "type": node_type}
+    children = getattr(node, "children", None) or []
+    if children:
+        result["children"] = [_tree_to_json(child) for child in children]
+    return result
+
+
+def describe_scenario(file_path):
+    """What does *this* `.osc` file actually reference and DO, and does it resolve?
+
+    Two independent sources, because they fail independently: ``actions_used``
+    comes from scanning the file's own text (see :func:`_scan_actions_used` for
+    why), so it is complete even when the file does not resolve at all;
+    ``tree`` comes from the same parse/resolve pipeline :func:`validate` uses
+    (via the shared :func:`_run_pipeline`, so there is no duplicate parsing),
+    and is only non-``None`` when that pipeline actually built a py-tree.
+
+    Returns ``{"valid": bool, "diagnostics": [...], "actions_used": [...],
+    "tree": {...} | None}`` — ``diagnostics`` is exactly :func:`validate`'s own
+    shape; ``actions_used`` items are ``{name, kind, doc, resolvable}``; ``tree``
+    is ``{name, type, children}`` recursed from the built py-tree, or ``None``.
+    """
+    tree, diagnostics, valid = _run_pipeline(file_path, level="full")
+    catalog = list_actions()
+    actions_used = _scan_actions_used(file_path, catalog)
+    return {
+        "valid": valid,
+        "diagnostics": diagnostics,
+        "actions_used": actions_used,
+        "tree": _tree_to_json(tree) if tree is not None else None,
+    }
+
+
 # ── Module CLI (python -m scenario_execution.introspection <subcommand>) ──────
 
 def main(argv=None):
@@ -350,13 +523,29 @@ def main(argv=None):
         "list-actions",
         help="List the DSL vocabulary available in this environment, as JSON.")
 
+    p_get_action = sub.add_parser(
+        "get-action", help="One action/modifier/actor/struct's full catalog entry, as JSON.")
+    p_get_action.add_argument("name", help="Exact name, e.g. 'differential_drive_robot.nav_to_pose'")
+
+    p_describe = sub.add_parser(
+        "describe", help="What a .osc file references and builds, as JSON.")
+    p_describe.add_argument("file", help="Path to the .osc scenario file")
+
     args = parser.parse_args(argv)
     if args.command == "validate":
         result = validate(args.file, level=args.level, debug=args.debug)
         print(json.dumps(result, indent=2))
         sys.exit(0 if result["valid"] else 1)
-    else:  # list-actions
+    elif args.command == "list-actions":
         print(json.dumps(list_actions(), indent=2))
+    elif args.command == "get-action":
+        result = get_action_details(args.name)
+        print(json.dumps(result, indent=2))
+        sys.exit(1 if "error" in result else 0)
+    else:  # describe
+        result = describe_scenario(args.file)
+        print(json.dumps(result, indent=2))
+        sys.exit(0 if result["valid"] else 1)
 
 
 if __name__ == "__main__":

--- a/scenario_execution/test/test_introspection.py
+++ b/scenario_execution/test/test_introspection.py
@@ -21,8 +21,11 @@ import tempfile
 import unittest
 
 from scenario_execution.introspection import (_parse_osc_library,
-                                               _syntax_diagnostics, list_actions,
-                                               validate)
+                                              _scan_actions_used,
+                                              _syntax_diagnostics,
+                                              _tree_to_json, describe_scenario,
+                                              get_action_details, list_actions,
+                                              validate)
 
 
 class TestParseOscLibrary(unittest.TestCase):
@@ -52,6 +55,24 @@ class TestParseOscLibrary(unittest.TestCase):
         self.assertEqual(msg["doc"], "the message to log")
         # A parameter with no default / no comment reports None, not "".
         self.assertIsNone(decl["parameters"][1]["default"])
+
+    def test_dotted_action_name_kept_whole(self):
+        # A regression guard: [A-Za-z_]\w* alone truncates "actor.method" at the
+        # dot, collapsing every action on one actor type into the same (kind,
+        # name) key and silently dropping all but the first from the catalog.
+        text = (
+            "action differential_drive_robot.follow_waypoints:\n"
+            "    goal_poses: list of pose_3d\n"
+            "\n"
+            "action differential_drive_robot.nav_to_pose:\n"
+            "    goal: pose_3d\n"
+        )
+        decls = _parse_osc_library(text, "nav2")
+        names = {d["name"] for d in decls}
+        self.assertEqual(
+            names,
+            {"differential_drive_robot.follow_waypoints",
+             "differential_drive_robot.nav_to_pose"})
 
     def test_multiple_kinds_separated(self):
         text = "actor base\n\nstruct point:\n    x: float\n"
@@ -141,6 +162,111 @@ class TestListActions(unittest.TestCase):
         for bucket in list_actions().values():
             names = [d["name"] for d in bucket]
             self.assertEqual(names, sorted(names))
+
+
+class TestGetActionDetails(unittest.TestCase):
+
+    def test_known_name_matches_list_actions_entry(self):
+        catalog = list_actions()
+        some_action = catalog["actions"][0]
+        self.assertEqual(get_action_details(some_action["name"]), some_action)
+
+    def test_unknown_name_is_error(self):
+        result = get_action_details("totally_made_up_name_xyz")
+        self.assertIn("error", result)
+
+
+class TestScanActionsUsed(unittest.TestCase):
+    """Pure, environment-independent: uses a hand-built catalog, not list_actions()."""
+
+    CATALOG = {
+        "actions": [{"name": "differential_drive_robot.nav_to_pose", "kind": "action",
+                     "doc": "Nav to a pose.", "resolvable": True}],
+        "modifiers": [{"name": "timeout", "kind": "modifier",
+                      "doc": None, "resolvable": True}],
+        "actors": [{"name": "differential_drive_robot", "kind": "actor",
+                   "doc": None}],
+        "structs": [{"name": "pose_3d", "kind": "struct", "doc": None}],
+    }
+
+    def _write(self, content):
+        handle = tempfile.NamedTemporaryFile(
+            "w", suffix=".osc", delete=False, encoding="utf-8")
+        handle.write(content)
+        handle.close()
+        self.addCleanup(os.unlink, handle.name)
+        return handle.name
+
+    def test_instance_qualified_call_resolves_via_declared_type(self):
+        path = self._write(
+            "scenario test:\n"
+            "    timeout(10s)\n"
+            "    robot: differential_drive_robot\n"
+            "    do serial:\n"
+            "        robot.nav_to_pose(pose_3d(x: 1.0))\n"
+        )
+        found = {item["name"]: item for item in _scan_actions_used(path, self.CATALOG)}
+        self.assertIn("differential_drive_robot.nav_to_pose", found)
+        self.assertTrue(found["differential_drive_robot.nav_to_pose"]["resolvable"])
+        self.assertEqual(found["differential_drive_robot.nav_to_pose"]["kind"], "action")
+        self.assertIn("timeout", found)
+        self.assertIn("pose_3d", found)
+        self.assertEqual(found["pose_3d"]["kind"], "struct")
+
+    def test_unknown_reference_reported_unresolvable(self):
+        path = self._write("scenario test:\n    do grasp_object()\n")
+        found = {item["name"]: item for item in _scan_actions_used(path, self.CATALOG)}
+        self.assertIn("grasp_object", found)
+        self.assertFalse(found["grasp_object"]["resolvable"])
+
+
+class TestTreeToJson(unittest.TestCase):
+    """Pure, environment-independent: builds a py_trees tree by hand."""
+
+    def test_sequence_with_modifier_wrapping_leaf(self):
+        import py_trees  # pylint: disable=import-outside-toplevel
+
+        leaf = py_trees.behaviours.Success(name="gripper.grasp")
+        modifier = py_trees.decorators.Inverter(name="timeout", child=leaf)
+        root = py_trees.composites.Sequence(name="pick_and_place", memory=True)
+        root.add_child(py_trees.behaviours.Success(name="differential_drive_robot.nav_to_pose"))
+        root.add_child(modifier)
+
+        result = _tree_to_json(root)
+        self.assertEqual(result["name"], "pick_and_place")
+        self.assertEqual(result["type"], "sequence")
+        self.assertEqual(len(result["children"]), 2)
+        self.assertEqual(result["children"][0]["type"], "action")
+        self.assertNotIn("children", result["children"][0])
+        modifier_json = result["children"][1]
+        self.assertEqual(modifier_json["type"], "modifier")
+        self.assertEqual(len(modifier_json["children"]), 1)
+        self.assertEqual(modifier_json["children"][0]["name"], "gripper.grasp")
+
+
+class TestDescribeScenario(unittest.TestCase):
+
+    def _write(self, content):
+        handle = tempfile.NamedTemporaryFile(
+            "w", suffix=".osc", delete=False, encoding="utf-8")
+        handle.write(content)
+        handle.close()
+        self.addCleanup(os.unlink, handle.name)
+        return handle.name
+
+    def test_unresolvable_reference_yields_null_tree_but_full_actions_used(self):
+        path = self._write(
+            "import osc.helpers\n\nscenario test:\n    do totally_unknown_action()\n")
+        report = describe_scenario(path)
+        self.assertFalse(report["valid"])
+        self.assertIsNone(report["tree"])
+        names = {item["name"] for item in report["actions_used"]}
+        self.assertIn("totally_unknown_action", names)
+
+    def test_shape_has_all_four_keys(self):
+        path = self._write("import osc.helpers\n\nscenario test:\n    log(msg: \"hi\")\n")
+        report = describe_scenario(path)
+        self.assertEqual(set(report), {"valid", "diagnostics", "actions_used", "tree"})
 
 
 if __name__ == "__main__":

--- a/simulation/gazebo/gazebo_tf_publisher/src/gazebo_tf_publisher_node.cpp
+++ b/simulation/gazebo/gazebo_tf_publisher/src/gazebo_tf_publisher_node.cpp
@@ -47,7 +47,28 @@ GazeboTFPublisher::GazeboTFPublisher() : Node("gazebo_tf_publisher") {
 
 void GazeboTFPublisher::simulationCallback(const gz::msgs::Pose_V &poses) {
   auto tf_msg = std::make_shared<tf2_msgs::msg::TFMessage>();
-  auto ros2_clock = get_clock()->now();
+  // Stamp with the simulator's own time for this pose batch, not with our
+  // clock.
+  //
+  // get_clock()->now() under use_sim_time is the last /clock message this node
+  // happened to have received, so it is quantised to the /clock publish grid
+  // and carries the subscriber-callback delay on top. Downstream that stamp IS
+  // the measurement time: anything differentiating these poses -- a speed, a
+  // rate -- divides by an interval that came from the transport rather than
+  // from the motion, which turns a constant speed into an alternating one
+  // whenever the grid does not divide the publish period.
+  //
+  // SceneBroadcaster fills Pose_V's header with the sim time of the batch
+  // (verified against gz-sim 8 on /world/<name>/dynamic_pose/info), so the
+  // exact value is already here and was simply being dropped. The fallback
+  // keeps a publisher that leaves the header empty working exactly as before
+  // rather than stamping everything zero.
+  rclcpp::Time ros2_clock = (poses.has_header() && poses.header().has_stamp())
+                                // gz spells it `nsec`, unlike ROS's `nanosec`.
+                                ? rclcpp::Time(poses.header().stamp().sec(),
+                                               poses.header().stamp().nsec(),
+                                               get_clock()->get_clock_type())
+                                : get_clock()->now();
   for (int i = 0; i < poses.pose_size(); i++) {
     if (poses.pose(i).name() == base_frame_id) {
       // each robot_frame_id is expected to have corresponding


### PR DESCRIPTION
### Description
Builds on the introspection module from #75: adds per-name lookup, a whole-file
"what does this scenario reference and build" report, and an MCP server exposing
them, so an agent or IDE can answer scenario questions without a shell.

Issue Number: #TODO

### Pull request checklist
- [ ] [Issue](https://github.com/cps-test-lab/scenario-execution/issues) created that explains the change and why it's needed
- [x] Tests are part of the PR (for bug fixes / features)
- [ ] [Docs](https://cps-test-lab.github.io/scenario-execution/) reviewed and added / updated if needed (for bug fixes / features)
- [x] Format and Lint checks (`make check`) pass locally
- [x] PR applies Apache 2.0 License to all code files

### Pull request type
- [x] Feature

### Current behavior
`scenario_execution.introspection` (#75) answers two questions: `list_actions()`
dumps the whole DSL vocabulary of the environment, and `validate()` reports
diagnostics for a `.osc` file. Between them there is nothing that answers
"what does *this* file use, and did those references resolve" — a caller has to
re-scan the full catalog to look up one name, and a `valid: false` result names
the first failing reference without saying what else the file references. Both
are reachable only from a shell, via `python -m scenario_execution.introspection`.

Also, the catalog regex matches declaration names as `[A-Za-z_]\w*`, which
truncates a qualified action name at its first dot: every action on one actor
type collapses into the same `(kind, name)` key and all but the first are
dropped by `list_actions()`'s dedup. On nav2 that silently loses most of
`differential_drive_robot.*`.

### New behavior
* `get_action_details(name)` — one catalog entry by exact name, or an error.
* `describe_scenario(path)` — `{valid, diagnostics, actions_used, tree}` for one
  file. `actions_used` comes from a text scan rather than a walk of the resolved
  model, deliberately: semantic resolution aborts at the first bad reference, so
  a model walk would under-report everything past a single typo. It therefore
  stays complete even for a file that does not resolve at all, with each entry
  flagged `resolvable`. `tree` is the py_trees tree the pipeline built, as plain
  JSON (walking `.name`/`.children`, not re-parsing `unicode_tree`'s ASCII), or
  `null` when nothing was built.
* `validate()` keeps its exact return shape: it and `describe_scenario()` are now
  both thin wrappers over one shared `_run_pipeline()`, so there is no second
  parse and no second place for the diagnostics shape to drift.
* Catalog regex accepts internal dots, with a regression test.
* Two new CLI subcommands: `get-action <name>` and `describe <file>`.
* New sibling package `scenario_execution_mcp`: the same four functions
  registered as MCP tools over stdio (`python -m scenario_execution_mcp` or the
  `scenario_execution_mcp` console script). No new logic — a second thin adapter
  next to the CLI.
* Doc comments filled in for the `floorplan_dsl.osc` and `pybullet.osc`
  declarations that were missing them (they surface directly in the catalog now).

### How to test
    # 19 unit tests, no ROS needed; the py_trees/scan tests are environment-independent
    python -m pytest scenario_execution/test/test_introspection.py

    # inside a runtime image, so ROS/nav2/gazebo action libraries resolve:
    python -m scenario_execution.introspection get-action differential_drive_robot.nav_to_pose
    python -m scenario_execution.introspection describe <some>.osc      # exit 1 if invalid
    python -m scenario_execution.introspection list-actions | \
      python -c "import json,sys; print(len(json.load(sys.stdin)['actions']))"
      # more than one differential_drive_robot.* entry -> the regex fix is in

    # MCP server (needs fastmcp), 3 unit tests plus a live client:
    python -m pytest libs/scenario_execution_mcp/test/test_mcp_server.py
    python -m scenario_execution_mcp

### Note for reviewers
`fastmcp` is in the new package's `install_requires` but has no rosdep key, so it
is not in its `package.xml`. The package is opt-in — nothing else depends on it —
but please say how you would prefer that dependency declared before merge, and
whether CI's workspace build needs it excluded.
