### PR TITLE
Fix check_data comparing messages received before the action starts

### DIFF
--- a/scenario_execution_ros/scenario_execution_ros/actions/ros_topic_check_data.py
+++ b/scenario_execution_ros/scenario_execution_ros/actions/ros_topic_check_data.py
@@ -47,6 +47,10 @@ class RosTopicCheckData(BaseAction):
         self.last_msg = None
         self.found = None
         self.comparison_text = ""
+        # The subscription is created in setup(), but the values to compare against only
+        # arrive with execute(). Until then the callback exists solely to retain last_msg
+        # for the wait_for_first_message: false case -- see _callback().
+        self.started = False
 
     def setup(self, **kwargs):
         """
@@ -93,6 +97,7 @@ class RosTopicCheckData(BaseAction):
             self.check_data(self.last_msg)
             if self.found is True:
                 self.feedback_message = f"Found expected value in previously received message."  # pylint: disable= attribute-defined-outside-init
+        self.started = True
 
     def update(self) -> py_trees.common.Status:
         if self.found is True:
@@ -105,6 +110,12 @@ class RosTopicCheckData(BaseAction):
 
     def _callback(self, msg):
         self.last_msg = msg
+        # wait_for_first_message documents the check as starting with the first message
+        # received AFTER action execution, so a message arriving before execute() is only
+        # retained (for the wait_for_first_message: false case), never compared -- at that
+        # point expected_value and comparison_operator are still unset.
+        if not self.started:
+            return
         self.check_data(msg)
         if self.found is True:
             self.feedback_message = f"Found expected value in received message."
@@ -123,6 +134,7 @@ class RosTopicCheckData(BaseAction):
                 value = check_attr(msg)
             except AttributeError:
                 self.feedback_message = f"Member name not found {self.member_name}"
+                return
         self.comparison_text = f"{value} {self.comparison_operator.__name__} {self.expected_value}"
         self.found = self.comparison_operator(value, self.expected_value)
 


### PR DESCRIPTION
## Problem

`check_data` creates its subscription in `setup()`, but the values it compares against
(`expected_value`, `comparison_operator`) are only assigned in `execute()`. In between, the
action is subscribed but not configured — and `_callback` compared every message it received.

That contradicts the declared semantics of `wait_for_first_message` (default `true`):

```
wait_for_first_message: bool = true  # start checking with the first received message after
                                     # action execution. If false, the check is executed on
                                     # the last received message
```

The early subscription exists so `last_msg` is available for the `false` case — those messages
should be *retained*, not *compared*.

The early comparisons were harmless only by accident: `check_data` returns early while
`expected_value` is `None`. But `execute()` sets the two values on consecutive statements:

```python
self.set_expected_value(expected_value, eval_expected_value)             # guard now passes
self.comparison_operator = get_comparison_operator(comparison_operator)  # still None
```

A message landing between them gets past the guard and reaches
`self.comparison_operator.__name__`, raising `'NoneType' object has no attribute '__name__'`
inside the subscription callback and killing the run.

Narrow, but reachable — hit once in 80 runs of a navigation campaign, on a check against
`/scan` (a `sensor_data`-QoS topic that floods as soon as the simulator comes up, immediately
after `wait_for_topics`). The run died 1.3 s in, before it could record anything.

## Fix

Gate `_callback` on an explicit `started` flag, set at the end of `execute()`. This states the
documented rule directly — nothing is compared until the action has started — instead of
depending on which attributes happen to still be `None`. `last_msg` is still updated on every
message, so `wait_for_first_message: false` is unaffected: `execute()` checks it explicitly,
after both values are set.

Also included: a missing `return` after the `AttributeError` handler in `check_data`. An
unresolvable `member_name` left `value` unbound, so the next line raised `UnboundLocalError`
instead of surfacing the intended "Member name not found" message.

## Notes

`ros_topic_check_data_external.py` shares the early-subscription design but is not affected —
its `check_function` is assigned in `setup()` before the subscription is created, so it has no
unconfigured window.